### PR TITLE
Fix uncategorized transactions filter parameter mismatch

### DIFF
--- a/backend/src/routes/transactions.js
+++ b/backend/src/routes/transactions.js
@@ -13,6 +13,7 @@ router.get('/', auth, async (req, res) => {
       endDate,
       type,
       category,
+      filter, // Support 'filter' parameter for backward compatibility
       subCategory,
       search,
       limit = '20',
@@ -21,12 +22,15 @@ router.get('/', auth, async (req, res) => {
       useProcessedDate = 'false'
     } = req.query;
 
+    // Use 'filter' parameter if 'category' is not provided (backward compatibility)
+    const finalCategory = category || filter;
+
     const validTypes = ['Expense', 'Income', 'Transfer'];
     const query = {
       startDate: startDate ? new Date(startDate) : undefined,
       endDate: endDate ? new Date(endDate) : undefined,
       type: validTypes.includes(type) ? type : undefined,
-      category,
+      category: finalCategory, // Use finalCategory which supports both 'category' and 'filter' params
       subCategory,
       search,
       limit: parseInt(limit),

--- a/frontend/src/components/dashboard/UncategorizedTransactionsWidget.tsx
+++ b/frontend/src/components/dashboard/UncategorizedTransactionsWidget.tsx
@@ -52,7 +52,8 @@ const UncategorizedTransactionsWidget: React.FC<UncategorizedTransactionsWidgetP
 
   const handleViewUncategorized = () => {
     // Navigate to transactions page with filter for uncategorized
-    navigate('/transactions?category=uncategorized');
+    // Using both parameters for maximum compatibility
+    navigate('/transactions?category=uncategorized&filter=uncategorized');
   };
 
   if (loading) {

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -28,9 +28,11 @@ const defaultFilters: Partial<TransactionFilters> = {
 const TransactionsPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const [filters, setFilters] = useState<Partial<TransactionFilters>>(() => {
-    // Check URL params on initial load
+    // Check URL params on initial load - support both 'category' and 'filter' for backward compatibility
     const categoryParam = searchParams.get('category');
-    if (categoryParam === 'uncategorized') {
+    const filterParam = searchParams.get('filter');
+    
+    if (categoryParam === 'uncategorized' || filterParam === 'uncategorized') {
       return {
         category: 'uncategorized',
         startDate: undefined,
@@ -49,14 +51,15 @@ const TransactionsPage: React.FC = () => {
   // Sync filters with URL parameters for backward compatibility
   useEffect(() => {
     const categoryParam = searchParams.get('category');
+    const filterParam = searchParams.get('filter');
     
-    if (categoryParam === 'uncategorized') {
+    if (categoryParam === 'uncategorized' || filterParam === 'uncategorized') {
       setFilters({
         category: 'uncategorized',
         startDate: undefined,
         endDate: undefined,
       });
-    } else if (!categoryParam && filters.category === 'uncategorized') {
+    } else if (!categoryParam && !filterParam && filters.category === 'uncategorized') {
       // If URL param is removed but filter is still uncategorized, reset to default
       setFilters(defaultFilters);
     }


### PR DESCRIPTION
## Problem
The uncategorized transactions filter wasn't working due to a URL parameter name mismatch. The system was expecting  but receiving  in some cases.

## Solution
This PR adds backward compatibility by supporting both parameter naming conventions:

### Changes Made:
- **Frontend ()**: Added support for both  and  URL parameters
- **Dashboard Widget ()**: Enhanced to send both parameters for maximum compatibility  
- **Backend ()**: Updated to accept both parameter names using 

### Testing:
✅ Tested clicking the uncategorized transactions action item from the dashboard
✅ Confirmed the filter now works correctly with both URL parameter formats
✅ Verified backward compatibility with existing URLs

## Impact
- Fixes the broken uncategorized transactions filter functionality
- Maintains backward compatibility with existing bookmarks/links
- Provides a more robust solution for URL parameter handling