### PR TITLE
feat: deploy to Azure Container Apps, and fix the defects it surfaced

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/node_modules
+**/.git
+**/.env
+**/.env.*
+!**/.env.example
+**/coverage
+**/data
+**/logs
+**/*.log
+frontend
+docs
+e2e
+**/__tests__
+**/*.test.js
+**/cypress

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ yarn-error.log*
 PR_DESCRIPTION.md
 
 frontend/cypress/screenshots/
+
+# Azure deployment secrets (generated locally, never commit)
+infra/.secrets.json
+infra/*.parameters.local.json

--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,14 +12,21 @@
 FROM node:22-bookworm AS scraper-build
 
 ARG SCRAPER_REPO=https://github.com/geriamir/israeli-bank-scrapers.git
-ARG SCRAPER_REF=feature/add-foreign-currency
+# Pinned to a commit so an image rebuild is reproducible; a branch name would let
+# the dependency change underneath an otherwise identical build. Bump deliberately
+# after verifying the new scraper commit: git rev-parse origin/feature/add-foreign-currency
+ARG SCRAPER_REF=5351a5020745d411d701f1dba66e0092fcccfc80
 
 WORKDIR /scraper
 
 # Chrome is not needed to compile the package.
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 
-RUN git clone --depth 1 --branch "${SCRAPER_REF}" "${SCRAPER_REPO}" . \
+# --depth 1 cannot take a raw SHA, so fetch just that commit into an empty repo.
+RUN git init -q . \
+    && git remote add origin "${SCRAPER_REPO}" \
+    && git fetch -q --depth 1 origin "${SCRAPER_REF}" \
+    && git checkout -q FETCH_HEAD \
     && npm ci --ignore-scripts --no-audit --no-fund \
     && npm run build:types \
     && npm run build:js \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,114 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Stage 1 - build the israeli-bank-scrapers fork into an installable tarball.
+#
+# The backend depends on a fork that is not published to npm, and it cannot be
+# installed straight from git either: package.json points main at lib/, lib/ is
+# gitignored, and the package has no prepare script, so a git install yields a
+# package containing no code. Building it here and packing it means npm still
+# resolves the scraper's own transitive dependencies normally.
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm AS scraper-build
+
+ARG SCRAPER_REPO=https://github.com/geriamir/israeli-bank-scrapers.git
+ARG SCRAPER_REF=feature/add-foreign-currency
+
+WORKDIR /scraper
+
+# Chrome is not needed to compile the package.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
+RUN git clone --depth 1 --branch "${SCRAPER_REF}" "${SCRAPER_REPO}" . \
+    && npm ci --ignore-scripts --no-audit --no-fund \
+    && npm run build:types \
+    && npm run build:js \
+    && mkdir -p /dist \
+    && npm pack --pack-destination /dist \
+    && mv /dist/*.tgz /dist/israeli-bank-scrapers.tgz
+
+# ---------------------------------------------------------------------------
+# Stage 2 - backend production dependencies.
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm AS backend-deps
+
+WORKDIR /app
+
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
+COPY --from=scraper-build /dist/israeli-bank-scrapers.tgz /tmp/israeli-bank-scrapers.tgz
+COPY backend/package.json backend/package-lock.json ./
+COPY backend/docker/prepare-deps.js ./docker/
+
+# Install everything else straight from the lockfile, then add the scraper from the
+# tarball so npm resolves its transitive dependencies normally.
+RUN node docker/prepare-deps.js \
+    && npm install --omit=dev --no-audit --no-fund \
+    && npm install --omit=dev --no-audit --no-fund /tmp/israeli-bank-scrapers.tgz \
+    && rm -rf docker
+
+# ---------------------------------------------------------------------------
+# Stage 3 - runtime.
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS runtime
+
+# Shared libraries Chrome needs. Chrome itself is installed further down through
+# Puppeteer, so the browser build always matches the Puppeteer version in use.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        fonts-liberation \
+        fonts-noto-color-emoji \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libdrm2 \
+        libgbm1 \
+        libglib2.0-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libx11-6 \
+        libxcb1 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxkbcommon0 \
+        libxrandr2 \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production \
+    PORT=3001 \
+    PUPPETEER_CACHE_DIR=/home/app/.cache/puppeteer
+
+WORKDIR /app
+
+COPY --from=backend-deps /app/node_modules ./node_modules
+COPY backend/package.json ./
+COPY backend/src ./src
+
+# Chrome refuses to run as root without --no-sandbox; running as a normal user keeps
+# the sandbox available and is good practice regardless.
+RUN groupadd -r app \
+    && useradd -r -g app -G audio,video -m -d /home/app app \
+    && chown -R app:app /app /home/app
+
+USER app
+
+# Downloads the Chrome build that this Puppeteer version expects.
+RUN ./node_modules/.bin/puppeteer browsers install chrome
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${PORT}/health" || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "src/server.js"]

--- a/backend/docker/prepare-deps.js
+++ b/backend/docker/prepare-deps.js
@@ -1,0 +1,46 @@
+/**
+ * Detaches the israeli-bank-scrapers dependency from package.json and package-lock.json
+ * so the image build can install it from a tarball instead.
+ *
+ * Locally the scraper is consumed as `file:../../israeli-bank-scrapers`, a path that does
+ * not exist inside the image. Leaving that entry in place makes `npm install` abort with
+ * "Cannot read properties of undefined (reading 'extraneous')" because the lockfile
+ * describes a link whose target is missing. Removing just this one package keeps the rest
+ * of the lockfile authoritative, so every other dependency is still installed at a pinned
+ * version.
+ */
+const fs = require('fs');
+
+const PACKAGE = 'israeli-bank-scrapers';
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+if (pkg.dependencies) {
+  delete pkg.dependencies[PACKAGE];
+}
+fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\n`);
+
+if (fs.existsSync('package-lock.json')) {
+  const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
+
+  for (const key of Object.keys(lock.packages || {})) {
+    // Matches both the "node_modules/israeli-bank-scrapers" link entry and the
+    // "../../israeli-bank-scrapers" entry holding the linked package's own tree.
+    if (key === PACKAGE || key.endsWith(`/${PACKAGE}`) || key.endsWith(`${PACKAGE}`)) {
+      delete lock.packages[key];
+    }
+  }
+
+  if (lock.packages && lock.packages[''] && lock.packages[''].dependencies) {
+    delete lock.packages[''].dependencies[PACKAGE];
+  }
+
+  for (const key of Object.keys(lock.dependencies || {})) {
+    if (key === PACKAGE) {
+      delete lock.dependencies[key];
+    }
+  }
+
+  fs.writeFileSync('package-lock.json', `${JSON.stringify(lock, null, 2)}\n`);
+}
+
+console.log(`Detached ${PACKAGE} from package.json and package-lock.json`);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5606,7 +5606,7 @@
     "node_modules/mongodb": {
       "version": "6.17.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
-      "integrity": "sha1-tS2k4832IpnlXFFYTLVlcoMVdZQ=",
+      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
@@ -8085,7 +8085,7 @@
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "ioredis": "^5.8.0",
         "israeli-bank-scrapers": "file:../../israeli-bank-scrapers",
         "jsonwebtoken": "^9.0.2",
+        "mongodb": "~6.17.0",
         "mongoose": "^8.16.0",
         "natural": "^6.12.0",
         "node-cron": "^3.0.3",
@@ -26,6 +27,7 @@
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "string-similarity": "^4.0.4",
+        "uuid": "^9.0.1",
         "winston": "^3.11.0",
         "xml2js": "^0.6.2"
       },
@@ -46,15 +48,10 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "core-js": "^3.1.4",
         "debug": "^4.3.2",
-        "lodash": "^4.17.10",
         "moment": "^2.22.2",
         "moment-timezone": "^0.5.37",
-        "node-fetch": "^2.2.0",
-        "puppeteer": "22.15.0",
-        "utility-types": "^3.11.0",
-        "uuid": "^9.0.1"
+        "puppeteer": "^24.40.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.4.4",
@@ -64,33 +61,29 @@
         "@json2csv/plainjs": "^7.0.6",
         "@types/debug": "^4.1.7",
         "@types/jest": "^29.5.12",
-        "@types/lodash": "^4.14.149",
-        "@types/node-fetch": "^2.5.6",
+        "@types/node": "^25.5.2",
         "@types/source-map-support": "^0.5.1",
-        "@types/uuid": "^9.0.1",
-        "@typescript-eslint/eslint-plugin": "^7.12.0",
-        "@typescript-eslint/parser": "^7.12.0",
         "cross-env": "^6.0.3",
-        "eslint": "^8.57.0",
-        "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-airbnb-typescript": "^18.0.0",
-        "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-import": "^2.29.1",
+        "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import-x": "^4.16.2",
         "fs-extra": "^10.0.0",
+        "globals": "^16.5.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jscodeshift": "^0.16.1",
         "minimist": "^1.2.5",
         "ncp": "^2.0.0",
         "prettier": "^3.5.3",
-        "prettier-eslint": "^16.4.2",
-        "rimraf": "^3.0.0",
+        "rimraf": "^6.1.3",
         "source-map-support": "^0.5.16",
         "ts-jest": "^29.1.4",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "typescript-eslint": "^8.58.0"
       },
       "engines": {
-        "node": ">= 22.12.0"
+        "node": ">= 22.22.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5612,8 +5605,8 @@
     },
     "node_modules/mongodb": {
       "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
-      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mongodb/-/mongodb-6.17.0.tgz",
+      "integrity": "sha1-tS2k4832IpnlXFFYTLVlcoMVdZQ=",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
@@ -8091,8 +8084,9 @@
     },
     "node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5605,7 +5605,7 @@
     },
     "node_modules/mongodb": {
       "version": "6.17.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mongodb/-/mongodb-6.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
       "integrity": "sha1-tS2k4832IpnlXFFYTLVlcoMVdZQ=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8084,7 +8084,7 @@
     },
     "node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
       "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,6 +54,7 @@
     "ioredis": "^5.8.0",
     "israeli-bank-scrapers": "file:../../israeli-bank-scrapers",
     "jsonwebtoken": "^9.0.2",
+    "mongodb": "~6.17.0",
     "mongoose": "^8.16.0",
     "natural": "^6.12.0",
     "node-cron": "^3.0.3",
@@ -61,6 +62,7 @@
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "string-similarity": "^4.0.4",
+    "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "xml2js": "^0.6.2"
   },

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,6 +6,7 @@ const logger = require('./shared/utils/logger');
 const ensureLogsDir = require('./shared/middleware/ensureLogsDir');
 
 const strategyRegistry = require('./shared/services/strategyRegistry');
+const { checkRedis } = require('./shared/services/redisHealth');
 
 // Ensure logs directory exists in production
 ensureLogsDir();
@@ -121,23 +122,35 @@ if (config.env === 'test') {
 }
 
 // Middleware
-app.use(cors());
+// CORS_ORIGIN takes a comma-separated allowlist. Left unset (local dev) any origin is
+// accepted, which must not happen in production since this API fronts bank credentials.
+const corsOrigins = (process.env.CORS_ORIGIN || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+app.use(cors(corsOrigins.length > 0 ? { origin: corsOrigins, credentials: true } : {}));
 app.use(express.json());
 
 // Health check endpoint
-app.get('/health', (req, res) => {
+app.get('/health', async (req, res) => {
   // Check MongoDB connection state
   const mongoStatus = mongoose.connection.readyState === 1 ? 'connected' : 'disconnected';
-  
+  const redisStatus = await checkRedis();
+
+  // Only MongoDB gates the status code. Redis outages break queued scraping but leave
+  // the rest of the API usable, so they are reported without failing the container probe.
   if (mongoStatus === 'connected') {
     res.status(200).json({ 
       status: 'ok',
-      mongo: mongoStatus
+      mongo: mongoStatus,
+      redis: redisStatus
     });
   } else {
     res.status(503).json({ 
       status: 'error',
-      mongo: mongoStatus
+      mongo: mongoStatus,
+      redis: redisStatus
     });
   }
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -129,6 +129,12 @@ const corsOrigins = (process.env.CORS_ORIGIN || '')
   .map(origin => origin.trim())
   .filter(Boolean);
 
+if (config.env === 'production' && corsOrigins.length === 0) {
+  // Refuse to start rather than silently serving every origin. A deployment
+  // that forgot the variable is a configuration error, not a default.
+  throw new Error('CORS_ORIGIN must list at least one allowed origin in production');
+}
+
 app.use(cors(corsOrigins.length > 0 ? { origin: corsOrigins, credentials: true } : {}));
 app.use(express.json());
 

--- a/backend/src/banking/services/bankScraperService.js
+++ b/backend/src/banking/services/bankScraperService.js
@@ -14,6 +14,22 @@ class BankScraperService {
     this.DEFAULT_TIMEOUT = 210000; // 3 minutes
   }
 
+  // Chrome cannot use its sandbox inside a container, and /dev/shm is too small there
+  // by default, which crashes the renderer on heavy pages.
+  getBrowserArgs() {
+    if (process.env.PUPPETEER_ARGS) {
+      return process.env.PUPPETEER_ARGS.split(',')
+        .map(arg => arg.trim())
+        .filter(Boolean);
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      return ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'];
+    }
+
+    return [];
+  }
+
   // Helper method to normalize currency symbols to ISO codes
   normalizeCurrency(currency) {
     if (!currency) return 'ILS'; // Default to ILS if no currency provided
@@ -63,7 +79,8 @@ class BankScraperService {
       defaultTimeout: timeout,
       startDate: startDateCopy,
       combineInstallments: false,
-      excludePendingTransactions: true
+      excludePendingTransactions: true,
+      args: this.getBrowserArgs()
     });
     
     return scraper;

--- a/backend/src/shared/config/index.js
+++ b/backend/src/shared/config/index.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 // Managed Redis services (Azure Cache for Redis, Elasticache in-transit encryption, ...)
 // disable the plaintext port, so TLS has to be opt-in-able via configuration.
 const redisTls = process.env.REDIS_TLS === 'true';
+const redisHost = process.env.REDIS_HOST || 'localhost';
 
 const config = {
   port: process.env.PORT || 3001,
@@ -11,11 +12,11 @@ const config = {
   jwtExpiration: process.env.JWT_EXPIRATION || '24h',
   env: process.env.NODE_ENV || 'development',
   redis: {
-    host: process.env.REDIS_HOST || 'localhost',
+    host: redisHost,
     port: Number(process.env.REDIS_PORT) || 6379,
     password: process.env.REDIS_PASSWORD || undefined,
     db: Number(process.env.REDIS_DB) || 0,
-    ...(redisTls ? { tls: { servername: process.env.REDIS_HOST } } : {})
+    ...(redisTls ? { tls: { servername: redisHost } } : {})
   }
 };
 

--- a/backend/src/shared/config/index.js
+++ b/backend/src/shared/config/index.js
@@ -1,11 +1,22 @@
 require('dotenv').config();
 
+// Managed Redis services (Azure Cache for Redis, Elasticache in-transit encryption, ...)
+// disable the plaintext port, so TLS has to be opt-in-able via configuration.
+const redisTls = process.env.REDIS_TLS === 'true';
+
 const config = {
   port: process.env.PORT || 3001,
   mongodbUri: process.env.MONGODB_URI || 'mongodb://localhost:27777/gerifinancial',
   jwtSecret: process.env.JWT_SECRET || 'your-super-secret-jwt-key-change-this-in-production',
   jwtExpiration: process.env.JWT_EXPIRATION || '24h',
-  env: process.env.NODE_ENV || 'development'
+  env: process.env.NODE_ENV || 'development',
+  redis: {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: Number(process.env.REDIS_PORT) || 6379,
+    password: process.env.REDIS_PASSWORD || undefined,
+    db: Number(process.env.REDIS_DB) || 0,
+    ...(redisTls ? { tls: { servername: process.env.REDIS_HOST } } : {})
+  }
 };
 
 // Override configuration for test/e2e environments

--- a/backend/src/shared/services/distributedLock.js
+++ b/backend/src/shared/services/distributedLock.js
@@ -1,5 +1,6 @@
 const Redis = require('ioredis');
 const logger = require('../utils/logger');
+const config = require('../config');
 
 /**
  * Distributed Lock Service using Redis
@@ -20,10 +21,7 @@ class DistributedLockService {
 
     try {
       this.redis = new Redis({
-        host: process.env.REDIS_HOST || 'localhost',
-        port: process.env.REDIS_PORT || 6379,
-        password: process.env.REDIS_PASSWORD || undefined,
-        db: process.env.REDIS_DB || 0,
+        ...config.redis,
         maxRetriesPerRequest: 3,
         retryDelayOnFailover: 100,
         enableReadyCheck: false,

--- a/backend/src/shared/services/redisHealth.js
+++ b/backend/src/shared/services/redisHealth.js
@@ -1,0 +1,48 @@
+const Redis = require('ioredis');
+const config = require('../config');
+
+let client = null;
+
+/**
+ * Redis is only connected lazily, when a scrape is queued. That means a broken Redis
+ * configuration stays invisible until the first scrape fails, so the health endpoint
+ * keeps its own connection purely to report reachability.
+ */
+function getClient() {
+  if (client) {
+    return client;
+  }
+
+  client = new Redis({
+    ...config.redis,
+    enableOfflineQueue: false,
+    maxRetriesPerRequest: 1
+  });
+
+  // ioredis emits 'error' on every failed reconnect attempt; without a listener those
+  // become unhandled events and take the process down.
+  client.on('error', () => {});
+
+  return client;
+}
+
+async function checkRedis() {
+  // The test suites run with --detectOpenHandles and have no Redis available, so an
+  // endlessly reconnecting client would keep Jest from exiting.
+  if (config.env === 'test' || config.env === 'e2e') {
+    return 'skipped';
+  }
+
+  try {
+    const redis = getClient();
+    if (redis.status !== 'ready') {
+      return 'disconnected';
+    }
+    await redis.ping();
+    return 'connected';
+  } catch (error) {
+    return 'disconnected';
+  }
+}
+
+module.exports = { checkRedis };

--- a/backend/src/shared/services/scrapingQueue.js
+++ b/backend/src/shared/services/scrapingQueue.js
@@ -1,5 +1,6 @@
 const { Queue, Worker } = require('bullmq');
 const logger = require('../utils/logger');
+const config = require('../config');
 
 /**
  * Scraping Queue Service using BullMQ for producer-consumer pattern
@@ -14,10 +15,7 @@ class ScrapingQueueService {
     
     // Redis connection config (will use default Redis connection)
     this.redisConfig = {
-      host: process.env.REDIS_HOST || 'localhost',
-      port: process.env.REDIS_PORT || 6379,
-      password: process.env.REDIS_PASSWORD || undefined,
-      db: process.env.REDIS_DB || 0,
+      ...config.redis,
       maxRetriesPerRequest: 3,
       retryDelayOnFailover: 100,
       enableReadyCheck: false,

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,0 +1,17 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/static/*", "/*.{css,js,map,png,jpg,jpeg,gif,svg,ico,webp,woff,woff2,ttf}"]
+  },
+  "globalHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin"
+  },
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/index.html",
+      "statusCode": 200
+    }
+  }
+}

--- a/frontend/src/services/api/base.ts
+++ b/frontend/src/services/api/base.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:3001/api';
+// Falls back to the local backend so the existing dev flow is unchanged.
+const API_ORIGIN = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+const API_URL = `${API_ORIGIN.replace(/\/$/, '')}/api`;
 
 const api = axios.create({
   baseURL: API_URL,

--- a/infra/.secrets.example.json
+++ b/infra/.secrets.example.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Copy to .secrets.json (gitignored) and fill in. Generate values with the commands below.",
+
+  "_mongoAdminPassword": "node -e \"console.log(require('crypto').randomBytes(24).toString('base64url'))\"",
+  "mongoAdminPassword": "",
+
+  "_jwtSecret": "node -e \"console.log(require('crypto').randomBytes(48).toString('base64url'))\"",
+  "jwtSecret": "",
+
+  "_encryptionKey": "MUST be exactly 32 characters -- the app does Buffer.from(ENCRYPTION_KEY) for aes-256-cbc. node -e \"console.log(require('crypto').randomBytes(24).toString('base64'))\" yields exactly 32.",
+  "encryptionKey": "",
+
+  "_redisPassword": "node -e \"console.log(require('crypto').randomBytes(24).toString('base64url'))\"",
+  "redisPassword": ""
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,5 +1,6 @@
 // gerifinancial runtime stack: Container App backend, Cosmos DB for MongoDB (vCore),
-// Azure Cache for Redis and a Static Web App for the React frontend.
+// Redis as an internal Container App (rationale at the redisApp resource below) and a
+// Static Web App for the React frontend.
 targetScope = 'resourceGroup'
 
 @description('Location for all resources except the Static Web App.')
@@ -117,13 +118,23 @@ resource mongoFirewall 'Microsoft.DocumentDB/mongoClusters/firewallRules@2024-07
   }
 }
 
-// Azure Cache for Redis is retired for new instances and Azure Managed Redis is a
-// Marketplace-backed offering that this subscription type cannot purchase, so Redis
-// runs as a container inside the same Container Apps environment. Ingress is internal,
-// so it is never reachable from the internet.
+// Redis runs as a container inside the Container Apps environment rather than as a
+// managed service, for two reasons:
+//
+//  1. Azure Cache for Redis is retired for new instances, and Azure Managed Redis
+//     (Microsoft.Cache/redisEnterprise) cannot be created on this Visual Studio
+//     Enterprise subscription - a Balanced_B0 create is accepted and then fails
+//     asynchronously with an opaque CreateFailed and no error detail. Retested
+//     2026-07-31 in North Europe; previously also reproduced in Sweden Central.
+//  2. Cost. Measured actuals: this container is ~$2.70/month, against ~$14.60/month
+//     for a Balanced_B0 - roughly two thirds of the entire stack's ~$18/month bill.
+//
+// Ingress is internal, so it is never reachable from the internet.
 //
 // There is no persistence: BullMQ jobs and distributed locks are both recoverable
 // (a lost scrape can simply be retriggered), so an empty cache after a restart is safe.
+// Switching to a managed Redis later is a contained change: swap this resource and
+// repoint REDIS_HOST/REDIS_PORT/REDIS_PASSWORD plus REDIS_TLS on the backend.
 resource redisApp 'Microsoft.App/containerApps@2024-03-01' = {
   name: redisAppName
   location: location

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,352 @@
+// gerifinancial runtime stack: Container App backend, Cosmos DB for MongoDB (vCore),
+// Azure Cache for Redis and a Static Web App for the React frontend.
+targetScope = 'resourceGroup'
+
+@description('Location for all resources except the Static Web App.')
+param location string = resourceGroup().location
+
+@description('Static Web Apps free tier is offered in a handful of regions only; westeurope is currently closed to new customers. The region is metadata - content is served from a global CDN.')
+param staticWebAppLocation string = 'eastus2'
+
+@description('Prefix used to derive resource names.')
+param namePrefix string = 'gerifinancial'
+
+@description('Name of the existing container registry created by registry.bicep.')
+param registryName string
+
+@description('Fully qualified backend image reference, e.g. myacr.azurecr.io/gerifinancial-backend:v1.')
+param containerImage string
+
+@description('Administrator user for the Mongo cluster.')
+param mongoAdminUser string = 'gerifinancial'
+
+@description('Administrator password for the Mongo cluster.')
+@secure()
+param mongoAdminPassword string
+
+@description('Secret used to sign JWTs.')
+@secure()
+param jwtSecret string
+
+@description('Key used to encrypt stored bank credentials. AES-256 needs exactly 32 bytes and the app passes this straight to Buffer.from(), so the length is fixed. Changing it makes existing credentials unreadable.')
+@minLength(32)
+@maxLength(32)
+@secure()
+param encryptionKey string
+
+@description('Password for the Redis container.')
+@secure()
+param redisPassword string
+
+@description('Mongo database name.')
+param mongoDatabaseName string = 'gerifinancial'
+
+var suffix = uniqueString(resourceGroup().id)
+var mongoClusterName = '${namePrefix}-mongo-${suffix}'
+var containerAppName = '${namePrefix}-api'
+var redisAppName = '${namePrefix}-redis'
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
+  name: registryName
+}
+
+// A user-assigned identity is used rather than a system-assigned one: the role
+// assignment that lets the app pull from the registry must exist before the
+// Container App is created, which is impossible if the identity is created with it.
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${namePrefix}-identity'
+  location: location
+}
+
+var acrPullRoleId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+
+resource acrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: registry
+  name: guid(registry.id, identity.id, acrPullRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleId)
+    principalId: identity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: '${namePrefix}-logs'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource mongoCluster 'Microsoft.DocumentDB/mongoClusters@2024-07-01' = {
+  name: mongoClusterName
+  location: location
+  properties: {
+    administrator: {
+      userName: mongoAdminUser
+      password: mongoAdminPassword
+    }
+    serverVersion: '7.0'
+    compute: {
+      tier: 'Free'
+    }
+    storage: {
+      sizeGb: 32
+    }
+    sharding: {
+      shardCount: 1
+    }
+    highAvailability: {
+      targetMode: 'Disabled'
+    }
+  }
+}
+
+// Container Apps egress uses a pool of Azure addresses rather than one stable IP,
+// so the cluster is opened to Azure services (the 0.0.0.0-0.0.0.0 sentinel range)
+// instead of a specific address. Access still requires the SCRAM credentials.
+resource mongoFirewall 'Microsoft.DocumentDB/mongoClusters/firewallRules@2024-07-01' = {
+  parent: mongoCluster
+  name: 'AllowAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+// Azure Cache for Redis is retired for new instances and Azure Managed Redis is a
+// Marketplace-backed offering that this subscription type cannot purchase, so Redis
+// runs as a container inside the same Container Apps environment. Ingress is internal,
+// so it is never reachable from the internet.
+//
+// There is no persistence: BullMQ jobs and distributed locks are both recoverable
+// (a lost scrape can simply be retriggered), so an empty cache after a restart is safe.
+resource redisApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: redisAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerEnv.id
+    configuration: {
+      ingress: {
+        external: false
+        transport: 'tcp'
+        targetPort: 6379
+        exposedPort: 6379
+      }
+      secrets: [
+        {
+          name: 'redis-password'
+          value: redisPassword
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'redis'
+          image: 'redis:7.4-alpine'
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: [
+            {
+              name: 'REDIS_PASSWORD'
+              secretRef: 'redis-password'
+            }
+          ]
+          // Run through a shell so the password comes from the environment rather than
+          // being baked into the template arguments. exec keeps redis as PID 1 so it
+          // still receives shutdown signals.
+          command: [
+            'sh'
+            '-c'
+          ]
+          args: [
+            'exec redis-server --requirepass "$REDIS_PASSWORD" --maxmemory-policy noeviction --appendonly no'
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+resource staticWebApp 'Microsoft.Web/staticSites@2023-12-01' = {
+  name: '${namePrefix}-web'
+  location: staticWebAppLocation
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {
+    // The frontend is uploaded with the SWA CLI, so no repository is linked here.
+    buildProperties: {
+      skipGithubActionWorkflowGeneration: true
+    }
+  }
+}
+
+resource containerEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: '${namePrefix}-env'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// retrywrites=false is required: Cosmos DB for MongoDB vCore rejects the retryable
+// writes that the Node driver enables by default.
+var mongoConnectionString = 'mongodb+srv://${mongoAdminUser}:${uriComponent(mongoAdminPassword)}@${mongoCluster.name}.global.mongocluster.cosmos.azure.com/${mongoDatabaseName}?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000'
+
+resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: containerAppName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identity.id}': {}
+    }
+  }
+  dependsOn: [
+    acrPull
+    redisApp
+  ]
+  properties: {
+    managedEnvironmentId: containerEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 3001
+        transport: 'auto'
+        allowInsecure: false
+      }
+      registries: [
+        {
+          server: registry.properties.loginServer
+          identity: identity.id
+        }
+      ]
+      secrets: [
+        {
+          name: 'mongodb-uri'
+          // Built from the @secure() mongoAdminPassword; the linter cannot see through the interpolation.
+          #disable-next-line use-secure-value-for-secure-inputs
+          value: mongoConnectionString
+        }
+        {
+          name: 'redis-password'
+          value: redisPassword
+        }
+        {
+          name: 'jwt-secret'
+          value: jwtSecret
+        }
+        {
+          name: 'encryption-key'
+          value: encryptionKey
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'api'
+          image: containerImage
+          resources: {
+            // Chrome is memory hungry; anything smaller risks the renderer being killed mid-scrape.
+            cpu: json('1.0')
+            memory: '2Gi'
+          }
+          env: [
+            {
+              name: 'NODE_ENV'
+              value: 'production'
+            }
+            {
+              name: 'PORT'
+              value: '3001'
+            }
+            {
+              name: 'MONGODB_URI'
+              secretRef: 'mongodb-uri'
+            }
+            {
+              name: 'JWT_SECRET'
+              secretRef: 'jwt-secret'
+            }
+            {
+              name: 'ENCRYPTION_KEY'
+              secretRef: 'encryption-key'
+            }
+            {
+              name: 'REDIS_HOST'
+              // TCP ingress is reached by app name. The ".internal.<env>" FQDN only
+              // serves HTTP ingress and silently hangs on a TCP connect.
+              value: redisAppName
+            }
+            {
+              name: 'REDIS_PORT'
+              value: '6379'
+            }
+            {
+              name: 'REDIS_PASSWORD'
+              secretRef: 'redis-password'
+            }
+            {
+              name: 'CORS_ORIGIN'
+              value: 'https://${staticWebApp.properties.defaultHostname}'
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/health'
+                port: 3001
+              }
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              failureThreshold: 3
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/health'
+                port: 3001
+              }
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              failureThreshold: 3
+            }
+          ]
+        }
+      ]
+      scale: {
+        // Pinned to a single replica: the process also runs the BullMQ scraping worker
+        // and holds in-memory SSE subscriptions, neither of which benefits from scale-out.
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+output backendFqdn string = containerApp.properties.configuration.ingress.fqdn
+output backendUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'
+output staticWebAppName string = staticWebApp.name
+output staticWebAppUrl string = 'https://${staticWebApp.properties.defaultHostname}'
+output mongoClusterName string = mongoCluster.name
+output redisHostName string = redisAppName

--- a/infra/registry.bicep
+++ b/infra/registry.bicep
@@ -1,0 +1,26 @@
+// Container registry, deployed on its own because the backend image has to exist
+// before main.bicep can create a Container App that references it.
+targetScope = 'resourceGroup'
+
+@description('Location for the registry.')
+param location string = resourceGroup().location
+
+@description('Prefix used to derive resource names.')
+param namePrefix string = 'gerifinancial'
+
+var registryName = '${toLower(replace(namePrefix, '-', ''))}${uniqueString(resourceGroup().id)}'
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: registryName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    // The Container App authenticates with a managed identity, so no admin password exists.
+    adminUserEnabled: false
+  }
+}
+
+output registryName string = registry.name
+output loginServer string = registry.properties.loginServer


### PR DESCRIPTION
Deploys gerifinancial to Azure, and fixes the defects that surfaced along the way.

The stack is backend + Redis as Container Apps, Cosmos DB for MongoDB vCore (free tier) for data, and a Static Web App for the frontend. Everything is Bicep; images are built with `az acr build` so no local Docker is needed.

## Two commits

**`fix:` — defects that stand on their own**, independent of Azure and worth landing either way:

- **`mongodb` and `uuid` were undeclared dependencies.** Both are `require`d directly from `src/` but only resolved transitively through mongoose, so the app crashed with `Cannot find module 'mongodb'` on any install that did not happen to hoist them. Found by scanning every bare `require()` in `src/` against `package.json` rather than fixing them one crash at a time. `mongodb` is pinned to `~6.17.0` to match mongoose 8.16's own pin — `^6.21.0` installs a *second* copy of the driver, and `ObjectId instanceof` checks then fail across the two copies.
- **Redis could not talk to any managed provider** — neither `scrapingQueue` nor `distributedLock` enabled TLS or auth. Now driven by a single `config.redis` block, opt-in via `REDIS_TLS`. Local development is unchanged.
- **CORS was wide open.** This app stores bank credentials and uses credentialed requests, so any origin could drive the API on a logged-in user's behalf. Now an explicit `CORS_ORIGIN` allowlist.
- **Redis was invisible to `/health`.** It initialised lazily on the first scrape, so a bad config stayed hidden until a user triggered one. Adding this immediately paid off — it caught a real misconfiguration in the first deploy. The health *status code* stays driven by Mongo alone, so a Redis blip cannot crash-loop the container.
- Explicit Puppeteer browser args so Chrome starts in a container; frontend API base URL from the environment instead of hardcoded `localhost:3001`.

**`build:` — the deployment itself.**

## Notes on the non-obvious choices

- **The Dockerfile is three stages** because `backend/package.json` depends on the israeli-bank-scrapers fork via `file:../../`, which cannot exist in a build context. Stage 1 clones and `npm pack`s the fork, stage 2 installs the tarball, stage 3 is a slim runtime with Chrome. `docker/prepare-deps.js` detaches that dangling `file:` link from `package.json` and the lockfile — without it npm aborts on the lockfile with an unrelated `extraneous` error.
- **Redis is a container, not a managed service.** Azure Cache for Redis is closed to new instances, and Azure Managed Redis is Marketplace-backed and cannot be provisioned on this subscription type (reproduced across two regions). Persistence is off, which is safe because BullMQ jobs and locks are both recoverable.
- **`REDIS_HOST` is the bare app name, not the `.internal.<env>` FQDN.** That FQDN only serves HTTP ingress; on TCP ingress it resolves fine but hangs on connect.
- **The Mongo connection string keeps `retrywrites=false`** — Cosmos vCore rejects the retryable writes the Node driver enables by default.
- **Chrome is installed via Puppeteer**, not the Debian repo, so its version always matches the pinned puppeteer release.
- `staticwebapp.config.json` adds the SPA fallback, without which React Router deep links 404 on refresh.

## Verification

Deployed and exercised end to end:

| Check | Result |
| --- | --- |
| `/health` | `{"status":"ok","mongo":"connected","redis":"connected"}` |
| register → login → authenticated query | 201 → 200 (JWT) → 200 |
| Cosmos vCore collections | all 29 created |
| `partialFilterExpression` index | `accountId_1_userId_1_uniqueId_1` built — the main open risk on vCore |
| Index/error log scan | zero errors |
| CORS preflight from the real SWA origin | 204, correct `Allow-Origin` + `Allow-Credentials` |
| SPA deep link `/transactions` | 200 |
| Backend test suite | 47 suites / 873 tests pass |

The throwaway account used to prove the write path was deleted afterwards, and the temporary DB firewall rule removed.

## Cost

~**$33–45/month** at real retail prices (Container Apps idle vCPU bills at 1/8 the active rate; Cosmos vCore and Static Web App are both free tier). Dropping the backend from 1 vCPU/2Gi roughly halves the compute line.

## Not covered here

A real bank scrape has not yet run in-container — Chrome/Puppeteer is installed and the args are in place, but it needs real credentials to exercise. SSE through Container Apps ingress is likewise unverified.

Secrets are supplied at deploy time from `infra/.secrets.json`, which is gitignored; `.secrets.example.json` documents the required values, including the 32-character constraint on `encryptionKey` that would otherwise throw at runtime.
