### PR TITLE
fix(auth): wait for the session to be cleared before leaving the page

### DIFF
--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -38,9 +38,13 @@ const AuthLayout: React.FC = () => {
     setAnchorEl(null);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     handleClose();
-    logout();
+    // The session lives in an httpOnly cookie that only the server can clear,
+    // so the request has to finish before navigating. Navigating first can
+    // abort it, leaving the user looking signed out while the cookie is still
+    // valid.
+    await logout();
     navigate('/login');
   };
 

--- a/frontend/src/components/layout/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/AuthLayout.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuthLayout from '../AuthLayout';
+
+const mockNavigate = jest.fn();
+const mockLogout = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  Outlet: () => null,
+  useNavigate: () => mockNavigate
+}));
+
+jest.mock('../NavigationMenu', () => ({
+  NavigationMenu: () => null
+}));
+
+jest.mock('../../../contexts/ThemeContext', () => ({
+  useThemeMode: () => ({ mode: 'light', toggleTheme: jest.fn() })
+}));
+
+jest.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '1', email: 'logout@example.com', name: 'Logout User' },
+    logout: mockLogout
+  })
+}));
+
+describe('AuthLayout logout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // The session is an httpOnly cookie, so only the server can clear it.
+  // Navigating before that request resolves can abort it, which would leave the
+  // user looking at the login page while their cookie still works.
+  it('waits for the session to be cleared before navigating away', async () => {
+    const user = userEvent.setup();
+    let resolveLogout: () => void = () => {};
+    mockLogout.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = resolve;
+        })
+    );
+
+    render(<AuthLayout />);
+
+    await user.click(screen.getByTestId('user-avatar'));
+    await user.click(screen.getByText('Logout'));
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    resolveLogout();
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'));
+  });
+});

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -5,6 +5,8 @@ interface AuthContextType {
   user: AuthUser | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  /** Resolves once the session has been cleared. Never rejects: a failed
+   *  request is reported and the local state is cleared regardless. */
   logout: () => Promise<void>;
 }
 
@@ -34,6 +36,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const logout = useCallback(async () => {
     try {
       await authApi.logout();
+    } catch (error) {
+      // Deliberately not rethrown. The session cookie is httpOnly, so if the
+      // request fails there is nothing the page can do to end the session
+      // itself, and callers have no meaningful way to recover. Rejecting here
+      // would only strand them mid-sign-out.
+      console.error('Failed to clear the session on the server:', error);
     } finally {
       // Clear locally even if the request failed, so the user is not left
       // looking at a signed-in page they can no longer use.

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider, useAuth } from '../AuthContext';
+import { authApi } from '../../services/api';
+
+jest.mock('../../services/api', () => ({
+  authApi: {
+    getProfile: jest.fn(),
+    logout: jest.fn()
+  }
+}));
+
+const mockedApi = authApi as jest.Mocked<typeof authApi>;
+
+let logoutResult: Promise<void> | null = null;
+
+const Consumer: React.FC = () => {
+  const { isAuthenticated, isLoading, logout } = useAuth();
+
+  return (
+    <div>
+      <span data-testid="status">
+        {isLoading ? 'loading' : isAuthenticated ? 'signed-in' : 'signed-out'}
+      </span>
+      <button
+        onClick={() => {
+          logoutResult = logout();
+        }}
+      >
+        logout
+      </button>
+    </div>
+  );
+};
+
+const renderSignedIn = async () => {
+  mockedApi.getProfile.mockResolvedValue({
+    user: { id: '1', email: 'someone@example.com', name: 'Someone' }
+  } as Awaited<ReturnType<typeof authApi.getProfile>>);
+
+  render(
+    <AuthProvider>
+      <Consumer />
+    </AuthProvider>
+  );
+
+  await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('signed-in'));
+};
+
+describe('AuthContext logout', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logoutResult = null;
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('clears the session and resolves on success', async () => {
+    mockedApi.logout.mockResolvedValue(undefined);
+    await renderSignedIn();
+
+    await userEvent.click(screen.getByText('logout'));
+
+    await expect(logoutResult).resolves.toBeUndefined();
+    expect(screen.getByTestId('status')).toHaveTextContent('signed-out');
+  });
+
+  // Callers navigate away once this resolves, so a rejection would leave them
+  // stranded mid-sign-out with an unhandled promise rejection.
+  it('signs out locally and still resolves when the request fails', async () => {
+    mockedApi.logout.mockRejectedValue(new Error('network is down'));
+    await renderSignedIn();
+
+    await userEvent.click(screen.getByText('logout'));
+
+    await expect(logoutResult).resolves.toBeUndefined();
+    expect(screen.getByTestId('status')).toHaveTextContent('signed-out');
+    expect(consoleError).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Await the logout request before navigating away from the app.

```diff
-const handleLogout = () => {
+const handleLogout = async () => {
   handleClose();
-  logout();
+  await logout();
   navigate('/login');
 };
```

## Why

This was fire-and-forget, which was fine when the token lived in `localStorage` — signing out was purely a client-side act, so there was nothing to wait for.

Since #69 the session is an **httpOnly cookie that only the server can clear**, so the round trip *is* the logout. Navigating in the same tick can abort that request before it completes, and when it does the user lands on the login page still holding a valid cookie. The next visit to a protected route silently signs them back in.

The failure mode is quiet and looks like a UI glitch rather than a session that never ended, which is why it survived the OAuth migration unnoticed.

## How it surfaced

The `should logout successfully` e2e spec has been flaky since #69. Its second assertion is the one that matters:

```ts
cy.url().should('include', '/login');

// The session cookie is cleared server-side, so protected routes bounce.
cy.visit('/');
cy.url().should('include', '/login');
```

`cy.visit('/')` triggers a page load that can cancel the in-flight `POST /api/auth/logout`. The cookie survives, the app authenticates, and the URL stays at `/`. That is exactly the assertion that failed on #70 (`expected 'http://localhost:3000/' to include '/login'`) and passed on re-run — the test was right, the app was wrong.

## Test

`AuthLayout.test.tsx` pins the ordering by holding the logout promise open by hand:

```ts
await waitFor(() => expect(mockLogout).toHaveBeenCalled());
expect(mockNavigate).not.toHaveBeenCalled();   // must not have left yet

resolveLogout();
await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login'));
```

Verified it genuinely regresses — against the previous implementation it fails with `Number of calls: 1 → "/login"`, because navigation had already happened.

`AuthContext.logout` was also fixed as part of review: it used `try/finally` without a `catch`, so it cleared local state but still rethrew. Awaiting it would have turned a failed request into an unhandled rejection that skipped the navigation. It now reports the failure and resolves, and that contract is documented on the interface since `handleLogout` depends on it.

## Checks

Backend 932 passed / 6 skipped · frontend 208 passed (was 205) · eslint clean · `tsc --noEmit` clean · build succeeds.
