### PR TITLE
ci: deploy the frontend and backend from CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,231 @@
+name: Deploy
+
+# The frontend and the backend are deployed from the same place because they
+# have to move together: the OAuth migration shipped an API that no longer
+# accepted passwords while the Static Web App kept serving a build whose only
+# login form asked for one, and nothing noticed until someone tried to sign in.
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+# Deploys mutate shared infrastructure, so let an in-flight one finish rather
+# than racing it. Cancelling midway could leave the image pushed but the app
+# still on the old revision.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AZURE_RESOURCE_GROUP: rg-gerifinancial
+  REGISTRY: gerifinanciall2sld6nmx2xxq
+  CONTAINER_APP: gerifinancial-api
+  STATIC_WEB_APP: gerifinancial-web
+  API_URL: https://gerifinancial-api.livelymushroom-c563c2a6.northeurope.azurecontainerapps.io
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Work out what changed
+        id: filter
+        run: |
+          set -euo pipefail
+
+          emit() {
+            echo "backend=$1" >> "$GITHUB_OUTPUT"
+            echo "frontend=$2" >> "$GITHUB_OUTPUT"
+            echo "infra=$3" >> "$GITHUB_OUTPUT"
+          }
+
+          # A manual run is a deliberate "redeploy everything", usually because
+          # someone is recovering from a failed or skipped deploy.
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "Manual run: deploying both."
+            emit true true false
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          # A new branch or a force push leaves no usable base commit. Deploying
+          # everything is the safe answer: the alternative is skipping a deploy
+          # that was needed.
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+            echo "No usable base commit: deploying both."
+            emit true true false
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$before" "${{ github.sha }}")"
+          echo "Changed files:"
+          echo "$changed"
+
+          # A here-string rather than a pipe into `grep -q`: grep exits on its
+          # first match, which can leave the writing end of a pipe with SIGPIPE
+          # and make pipefail report a failure for a successful match.
+          contains() { grep -qE "$1" <<< "$changed"; }
+
+          backend=false
+          frontend=false
+          infra=false
+          if contains '^(backend/|\.github/workflows/deploy\.yml$)'; then backend=true; fi
+          if contains '^(frontend/|\.github/workflows/deploy\.yml$)'; then frontend=true; fi
+          if contains '^infra/'; then infra=true; fi
+
+          echo "backend=$backend frontend=$frontend infra=$infra"
+          emit "$backend" "$frontend" "$infra"
+
+  deploy-api:
+    name: Deploy API
+    needs: [ test, changes ]
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build and push image
+        id: image
+        run: |
+          set -euo pipefail
+          tag="$(date -u +%Y%m%d-%H%M%S)-${GITHUB_SHA::7}"
+          image="${REGISTRY}.azurecr.io/gerifinancial-api:${tag}"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+          # Built on the runner rather than with `az acr build`: a server-side
+          # build needs registry Contributor, while pushing needs only AcrPush.
+          az acr login -n "$REGISTRY"
+          docker build -f backend/Dockerfile -t "$image" .
+          docker push "$image"
+
+      - name: Roll out new revision
+        run: |
+          set -euo pipefail
+          az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors
+          az extension add --name containerapp --upgrade --only-show-errors
+          az containerapp update \
+            -n "$CONTAINER_APP" -g "$AZURE_RESOURCE_GROUP" \
+            --image "${{ steps.image.outputs.image }}" \
+            --only-show-errors --output none
+          az containerapp revision list -n "$CONTAINER_APP" -g "$AZURE_RESOURCE_GROUP" \
+            --query "[?properties.active].{revision:name,healthy:properties.healthState,created:properties.createdTime}" \
+            -o table
+
+      - name: Verify the API is serving
+        run: |
+          set -uo pipefail
+          # The image reference only proves the revision was accepted. This
+          # proves the container actually came up and reached its dependencies.
+          for attempt in $(seq 1 30); do
+            body="$(curl -fsS --max-time 10 "$API_URL/health" || true)"
+            echo "attempt $attempt: ${body:-<no response>}"
+            if [ -n "$body" ] && jq -e '.status == "ok"' >/dev/null 2>&1 <<< "$body"; then
+              echo "API healthy."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error title=API unhealthy::/health did not report ok after the rollout."
+          exit 1
+
+  deploy-frontend:
+    name: Deploy frontend
+    needs: [ test, changes ]
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: cd frontend && npm ci
+
+      - name: Build
+        run: cd frontend && npm run build
+        env:
+          CI: true
+          # Baked in at build time: a React build has no server side to read it
+          # from later, so a wrong value here ships a frontend that talks to
+          # nothing.
+          REACT_APP_API_URL: ${{ env.API_URL }}
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Static Web Apps
+        run: |
+          set -euo pipefail
+          # Fetched per run rather than stored as a repository secret: the
+          # deployment token is long lived and rotating it would otherwise mean
+          # remembering to update GitHub too.
+          token="$(az staticwebapp secrets list -n "$STATIC_WEB_APP" -g "$AZURE_RESOURCE_GROUP" \
+            --query properties.apiKey -o tsv)"
+          echo "::add-mask::$token"
+          npx --yes @azure/static-web-apps-cli deploy frontend/build \
+            --env production --deployment-token "$token"
+
+      - name: Verify the new bundle is being served
+        run: |
+          set -uo pipefail
+          # Guards against the failure this workflow exists to prevent: a deploy
+          # that reports success while the CDN keeps serving the previous build.
+          built="$(basename "$(ls frontend/build/static/js/main.*.js | head -1)")"
+          host="$(az staticwebapp show -n "$STATIC_WEB_APP" -g "$AZURE_RESOURCE_GROUP" \
+            --query defaultHostname -o tsv)"
+          echo "expecting $built on https://$host"
+
+          for attempt in $(seq 1 20); do
+            served="$(curl -fsS --max-time 10 "https://$host" \
+              | grep -oE 'main\.[a-f0-9]+\.js' | head -1 || true)"
+            echo "attempt $attempt: serving ${served:-<none>}"
+            if [ "$served" = "$built" ]; then
+              echo "Frontend is serving the build from this commit."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error title=Stale frontend::The site is not serving $built."
+          exit 1
+
+  infra-notice:
+    name: Infrastructure changed
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Warn that Bicep is not deployed automatically
+        run: |
+          echo "::warning title=Infrastructure not deployed::infra/ changed in this push. \
+          Bicep is deployed by hand on purpose - it holds secrets, locks and role assignments \
+          that should not roll out unreviewed. Follow docs/DEPLOYMENT.md."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,12 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# id-token is granted per job rather than here. The token can be exchanged for
+# Azure access, and the test and build jobs run the projects' whole npm
+# dependency trees - a compromised package in one of them has no business being
+# able to mint one.
 permissions:
   contents: read
-  id-token: write
 
 env:
   AZURE_RESOURCE_GROUP: rg-gerifinancial
@@ -86,7 +89,9 @@ jobs:
           backend=false
           frontend=false
           infra=false
-          if contains '^(backend/|\.github/workflows/deploy\.yml$)'; then backend=true; fi
+          # .dockerignore counts as backend: the image is built from the
+          # repository root, so it changes what lands in the image.
+          if contains '^(backend/|\.dockerignore$|\.github/workflows/deploy\.yml$)'; then backend=true; fi
           if contains '^(frontend/|\.github/workflows/deploy\.yml$)'; then frontend=true; fi
           if contains '^infra/'; then infra=true; fi
 
@@ -98,6 +103,9 @@ jobs:
     needs: [ test, changes ]
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -137,6 +145,10 @@ jobs:
       - name: Verify the API is serving
         run: |
           set -uo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::error title=jq missing::The health check parses /health with jq."
+            exit 1
+          fi
           # The image reference only proves the revision was accepted. This
           # proves the container actually came up and reached its dependencies.
           for attempt in $(seq 1 30); do
@@ -151,11 +163,17 @@ jobs:
           echo "::error title=API unhealthy::/health did not report ok after the rollout."
           exit 1
 
-  deploy-frontend:
-    name: Deploy frontend
+  build-frontend:
+    name: Build frontend
     needs: [ test, changes ]
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    # Deliberately no id-token. This job runs the frontend's entire dependency
+    # tree through npm ci and the build, and the deploy identity can replace
+    # the running API container - which can unwrap stored bank credentials. A
+    # compromised build-time package must not be able to reach that.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -177,6 +195,26 @@ jobs:
           # nothing.
           REACT_APP_API_URL: ${{ env.API_URL }}
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build
+          retention-days: 7
+          if-no-files-found: error
+
+  deploy-frontend:
+    name: Deploy frontend
+    needs: build-frontend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: build
+
       - uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -192,7 +230,9 @@ jobs:
           token="$(az staticwebapp secrets list -n "$STATIC_WEB_APP" -g "$AZURE_RESOURCE_GROUP" \
             --query properties.apiKey -o tsv)"
           echo "::add-mask::$token"
-          npx --yes @azure/static-web-apps-cli deploy frontend/build \
+          # Pinned rather than floating: this is the one npm package that runs
+          # in a job holding an Azure token.
+          npx --yes @azure/static-web-apps-cli@2.0.10 deploy build \
             --env production --deployment-token "$token"
 
       - name: Verify the new bundle is being served
@@ -200,7 +240,13 @@ jobs:
           set -uo pipefail
           # Guards against the failure this workflow exists to prevent: a deploy
           # that reports success while the CDN keeps serving the previous build.
-          built="$(basename "$(ls frontend/build/static/js/main.*.js | head -1)")"
+          shopt -s nullglob
+          bundles=(build/static/js/main.*.js)
+          if [ ${#bundles[@]} -eq 0 ]; then
+            echo "::error title=No bundle built::Expected build/static/js/main.*.js in the artifact."
+            exit 1
+          fi
+          built="$(basename "${bundles[0]}")"
           host="$(az staticwebapp show -n "$STATIC_WEB_APP" -g "$AZURE_RESOURCE_GROUP" \
             --query defaultHostname -o tsv)"
           echo "expecting $built on https://$host"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,11 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main, develop ]
+  # Called by deploy.yml, so pushes to main are gated by the same suite that
+  # gates pull requests instead of a second copy of it that can drift.
+  workflow_call:
 
 jobs:
   test:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -132,7 +132,24 @@ az keyvault secret set --vault-name gfkvl2sld6nmx2xxq \
 Sign-in stays disabled if either value is missing, so deploying without them is
 safe.
 
-## Deploying the backend
+## Deploying
+
+Pushes to `main` deploy themselves. `.github/workflows/deploy.yml` runs the unit
+test suite, then rebuilds and releases whichever of the two apps changed, and
+fails if the result is not actually being served. The sections below are the
+manual fallback, for a first-time environment or a broken pipeline.
+
+The workflow authenticates with a federated credential on the
+`gerifinancial-deploy` user-assigned identity, so no Azure credential is stored
+in GitHub. The identity is deliberately narrow - `AcrPush` on the registry and
+Contributor on the two app resources only. It has no access to either vault, so
+it cannot read application secrets.
+
+`infra/` is **not** deployed by CI. Bicep carries locks, role assignments and
+vault wiring that should not roll out unreviewed, so a push touching `infra/`
+only raises a warning in the run summary; deploy it by hand as below.
+
+### Deploying the backend by hand
 
 ```bash
 TAG="api-$(date +%Y%m%d-%H%M%S)"
@@ -156,10 +173,19 @@ az deployment group create -g rg-gerifinancial -n main -f infra/main.bicep \
 
 The build runs in ACR, so Docker is not needed locally.
 
-## Deploying the frontend
+`containerImage` has no default, and CI moves the image on without touching the
+template. When running Bicep for an unrelated infrastructure change, pass the
+tag that is **currently live** or the deploy will quietly roll the API back:
 
-The Static Web App is deployed with the SWA CLI, not from a GitHub workflow.
-The API URL is baked in at build time:
+```bash
+az containerapp show -n gerifinancial-api -g rg-gerifinancial \
+  --query "properties.template.containers[0].image" -o tsv
+```
+
+### Deploying the frontend by hand
+
+The Static Web App is deployed with the SWA CLI. The API URL is baked in at
+build time - a React build has no server side to read it from later:
 
 ```bash
 cd frontend
@@ -169,6 +195,17 @@ REACT_APP_API_URL=https://gerifinancial-api.livelymushroom-c563c2a6.northeurope.
 npx swa deploy build --env production \
   --deployment-token "$(az staticwebapp secrets list -n gerifinancial-web \
     -g rg-gerifinancial --query properties.apiKey -o tsv)"
+```
+
+Confirm the site is serving the build you just made rather than a cached one -
+deploying the API without the frontend once left production unable to sign in
+at all, because the served bundle still asked for a password the API had
+stopped accepting:
+
+```bash
+ls build/static/js/main.*.js                      # what you built
+curl -s https://witty-glacier-04eac040f.7.azurestaticapps.net \
+  | grep -o 'main\.[a-f0-9]*\.js'                 # what is served
 ```
 
 ## Verifying a deployment

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -145,6 +145,13 @@ in GitHub. The identity is deliberately narrow - `AcrPush` on the registry and
 Contributor on the two app resources only. It has no access to either vault, so
 it cannot read application secrets.
 
+Permission to mint that token is granted per job, not workflow-wide, and the
+frontend is built in a separate job from the one that deploys it. The jobs that
+run `npm ci` therefore cannot obtain Azure access: the deploy identity can
+replace the running API container, and that container's own identity can unwrap
+stored bank credentials, so a compromised build-time package would otherwise
+have a path to them.
+
 `infra/` is **not** deployed by CI. Bicep carries locks, role assignments and
 vault wiring that should not roll out unreviewed, so a push touching `infra/`
 only raises a warning in the run summary; deploy it by hand as below.


### PR DESCRIPTION
## Why

The OAuth migration (#69) shipped an API that no longer accepted passwords, while the Static Web App carried on serving a build whose only login form asked for one. **Production could not be signed into at all**, and nothing surfaced it — the two halves are deployed by hand, and only one of them was.

I deployed the frontend manually to fix production before opening this. This PR is about making that failure mode impossible to repeat.

## What

Pushes to `main` run the unit suite, then rebuild and release whichever app changed.

Both deploys end by checking what is **actually being served**, rather than trusting that the command returned success:

- the API must report `status: ok` on `/health` after the revision rolls out
- the site must return the exact bundle filename built from that commit

The second check is the one that would have caught this bug.

## Access

Azure auth is a federated credential on a new `gerifinancial-deploy` user-assigned identity, so **no Azure credential is stored in GitHub**. Only three non-secret identifiers are (client/tenant/subscription ID); the trust comes from the federated subject being pinned to `repo:geriamir/gerifinancial:ref:refs/heads/main`.

The identity is deliberately narrow — every assignment is scoped to a single resource:

| Role | Scope |
|---|---|
| `AcrPush` | the container registry |
| `Contributor` | `gerifinancial-api` container app |
| `Contributor` | `gerifinancial-web` static web app |

It has **no access to either vault**, so it cannot read application secrets. `AcrPush` rather than registry Contributor is why the image is built on the runner instead of with `az acr build` — a server-side build needs permission to schedule runs.

The SWA deployment token is fetched per run rather than stored as a repository secret, so rotating it doesn't mean remembering to update GitHub.

## Scope of automation

`infra/` is **not** deployed by CI. Bicep carries locks, role assignments and vault wiring that shouldn't roll out unreviewed, so a push touching `infra/` only raises a warning in the run summary.

That leaves one drift risk, now documented: `containerImage` has no default, so a later manual Bicep run must be passed the tag that is currently live or it will quietly roll the API back.

## Tests

`test.yml` moves to `workflow_call` and is invoked by the deploy workflow instead of triggering separately on `main`, so the same suite gates pushes and pull requests rather than a second copy that can drift. PR behaviour is unchanged.

Deploys gate on unit tests only. E2E still runs on `main` in parallel but doesn't block the deploy — it has already proven flaky (a spurious failure blocked #70), and a flake shouldn't hold up a release. Happy to change that if you'd rather deploys wait for it.

## Verification

- 5-check gate passes: 932 backend tests, 208 frontend, lint/`tsc`/build clean
- Both workflow files parse as YAML
- The change-detection logic was extracted and run against 9 cases in bash — backend-only, frontend-only, docs-only, infra-only, and combinations
- While testing it I found `echo "$changed" | grep -q` returns **141** under `pipefail` when grep matches early and the writer takes SIGPIPE, which would have marked a real backend change as "no change" and silently skipped the deploy. It needs a very large diff to trigger, but it's the exact failure this PR exists to prevent, so the check uses a here-string instead.
- The frontend build was re-run with `CI=true` (which GitHub Actions sets, and which makes CRA treat warnings as errors) to confirm it still compiles.

The workflow can't fully run until it's on `main`, so the first push after merge is its real test.
