### PR TITLE
ci: move the workflow actions onto Node 24 releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       infra: ${{ steps.filter.outputs.infra }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -107,9 +107,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: azure/login@v2
+      - uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -175,9 +175,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.x
           cache: npm
@@ -195,7 +195,7 @@ jobs:
           # nothing.
           REACT_APP_API_URL: ${{ env.API_URL }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: frontend-build
           path: frontend/build
@@ -210,12 +210,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: frontend-build
           path: build
 
-      - uses: azure/login@v2
+      - uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,10 +27,10 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -61,7 +61,7 @@ jobs:
         CI: true
 
     - name: Upload Cypress screenshots
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: cypress-screenshots
@@ -69,7 +69,7 @@ jobs:
         retention-days: 5
 
     - name: Upload Cypress videos
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: cypress-videos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
## Why

The first automated deploy (the run for #72) went green but annotated every job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

Runners already force these onto Node 24 and will eventually drop the compatibility shim. `test.yml` was two majors further behind than the rest, still on `@v3`.

## What

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v3 / v4 | **v7** |
| `actions/setup-node` | v3 / v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `azure/login` | v2 | **v3** |

## Verification

I checked the current majors rather than assuming the next one up — they had moved much further than expected (v7/v8, not v5), so a blind bump would have left most of this warning.

- Every major tag fetched and confirmed to declare `using: node24`
- Every input this repo passes confirmed to still exist on the new major: `client-id`/`tenant-id`/`subscription-id`, `node-version`/`cache`/`cache-dependency-path`, `name`/`path`/`retention-days`/`if-no-files-found`, `fetch-depth`
- All three workflows parse
- 5-check gate: 932 backend, 208 frontend, lint/`tsc`/build clean

**The artifact pair was the one real compatibility risk**, independent of inputs: `upload-artifact@v7` added unarchived single-file uploads that only `download-artifact@v8` can read back. The frontend build is a directory, so it is archived either way and the round trip is unaffected.

## Residual risk

`test.yml` and `e2e-tests.yml` are exercised by this PR itself, so `checkout`/`setup-node`/`upload-artifact` get validated before merge. `azure/login@v3` and the artifact round trip only run in `deploy.yml`, which cannot execute until this is on `main`.

If either regresses, the blast radius is a failed deploy, not a broken production — the running app is untouched until a deploy succeeds. I will watch the post-merge run.