### PR TITLE
Show categories arriving instead of leaving the list looking uncategorised

### DIFF
--- a/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
+++ b/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
@@ -150,9 +150,42 @@ describe('transactionCategorizationService', () => {
         transactionIds: [transaction._id]
       });
 
-      const complete = emit.mock.calls.find(([, type]) => type === 'categorization-complete');
+      const complete = emit.mock.calls.find(([, type]) => type === 'categorization:complete');
       expect(complete).toBeDefined();
       expect(complete[2]).toMatchObject({ total: 1 });
+    });
+
+    // Clients register under the string form of the id, so an ObjectId here
+    // matches nothing and the browser is never told the batch finished.
+    it('addresses events to the user id the SSE clients are keyed by', async () => {
+      jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
+      const emit = jest.spyOn(sseService, 'emit').mockImplementation(() => {});
+      const transaction = await makeTransaction();
+
+      await transactionCategorizationService.processBatch({
+        userId: user._id,
+        transactionIds: [transaction._id]
+      });
+
+      expect(emit).toHaveBeenCalled();
+      for (const [addressee] of emit.mock.calls) {
+        expect(addressee).toBe(user._id.toString());
+      }
+    });
+
+    it('reports progress as it goes so the browser can follow along', async () => {
+      jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
+      const emit = jest.spyOn(sseService, 'emit').mockImplementation(() => {});
+      const transaction = await makeTransaction();
+
+      await transactionCategorizationService.processBatch({
+        userId: user._id,
+        transactionIds: [transaction._id]
+      });
+
+      const progress = emit.mock.calls.find(([, type]) => type === 'categorization:progress');
+      expect(progress).toBeDefined();
+      expect(progress[2]).toMatchObject({ processed: 1, total: 1 });
     });
 
     it('reports progress to the job so a stalled batch is visible', async () => {

--- a/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
+++ b/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
@@ -150,7 +150,7 @@ describe('transactionCategorizationService', () => {
         transactionIds: [transaction._id]
       });
 
-      const complete = emit.mock.calls.find(([, type]) => type === 'categorization:complete');
+      const complete = emit.mock.calls.find(([, type]) => type === 'categorization:completed');
       expect(complete).toBeDefined();
       expect(complete[2]).toMatchObject({ total: 1 });
     });

--- a/backend/src/banking/services/transactionCategorizationService.js
+++ b/backend/src/banking/services/transactionCategorizationService.js
@@ -84,7 +84,7 @@ class TransactionCategorizationService {
       }
     }
 
-    sseService.emit(userIdStr, 'categorization:complete', {
+    sseService.emit(userIdStr, 'categorization:completed', {
       total: transactionIds.length,
       ...results
     });

--- a/backend/src/banking/services/transactionCategorizationService.js
+++ b/backend/src/banking/services/transactionCategorizationService.js
@@ -49,6 +49,10 @@ class TransactionCategorizationService {
    */
   async processBatch({ userId, transactionIds }, job) {
     const corpus = await transactionClassifier.forUser(userId);
+    // Clients are keyed by the string form of the id, and the job payload may
+    // hold either that or an ObjectId depending on the caller. Emitting with
+    // the wrong one finds no client and drops the event silently.
+    const userIdStr = userId.toString();
     const results = { categorized: 0, uncategorized: 0, failed: 0 };
 
     for (let i = 0; i < transactionIds.length; i += 1) {
@@ -67,9 +71,12 @@ class TransactionCategorizationService {
       }
 
       const done = i + 1;
-      if (job && (done % 10 === 0 || done === transactionIds.length)) {
-        await job.updateProgress(Math.round((done / transactionIds.length) * 100));
-        sseService.emit(userId, 'categorization-progress', {
+      if (done % 10 === 0 || done === transactionIds.length) {
+        // The job only exists while the queue is driving this. Whether the user
+        // is told how far along their transactions are should not depend on
+        // which caller happens to be running the batch.
+        await job?.updateProgress(Math.round((done / transactionIds.length) * 100));
+        sseService.emit(userIdStr, 'categorization:progress', {
           processed: done,
           total: transactionIds.length,
           ...results
@@ -77,7 +84,7 @@ class TransactionCategorizationService {
       }
     }
 
-    sseService.emit(userId, 'categorization-complete', {
+    sseService.emit(userIdStr, 'categorization:complete', {
       total: transactionIds.length,
       ...results
     });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,6 +155,15 @@ transactions, sets their type from the amount, and queues one
 batch and reports progress over SSE. A scrape therefore finishes as soon as the
 bank data is stored, and a slow or unavailable categoriser cannot hold it up.
 
+The cost of that split is that rows reach the browser before they have a
+category. `CategorizationProvider` (frontend) follows the
+`categorization:progress` and `categorization:complete` events, shows how far
+along the batch is, and hands the transaction lists a revision counter they use
+as a refresh trigger — so categories appear as they are assigned instead of on
+the next reload. The counter only advances when a report says transactions
+actually gained a category, to keep a few hundred of them from turning into
+dozens of refetches.
+
 `npm run eval:categorization` scores the cascade against a labelled fixture set
 and reports coverage, accuracy and which tier answered — the number any change
 here has to beat.
@@ -232,7 +241,12 @@ fan-out: clients subscribe per user, and any subsystem can push events to them
 without knowing about HTTP.
 
 The browser connects once to `GET /api/events` and receives scraping progress,
-completion and error notifications live.
+completion and error notifications live, along with categorisation progress.
+
+Named events are only delivered to listeners registered for that exact name, so
+`useSSE` keeps the list of subscribed events in `SSE_EVENT_TYPES`. An event the
+server emits but that list omits is dropped silently at both ends — adding an
+emit means adding its name there too.
 
 `EventSource` cannot set an `Authorization` header, so the stream authenticates
 with the same httpOnly session cookie as every other route — the client opts in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,7 +157,7 @@ bank data is stored, and a slow or unavailable categoriser cannot hold it up.
 
 The cost of that split is that rows reach the browser before they have a
 category. `CategorizationProvider` (frontend) follows the
-`categorization:progress` and `categorization:complete` events, shows how far
+`categorization:progress` and `categorization:completed` events, shows how far
 along the batch is, and hands the transaction lists a revision counter they use
 as a refresh trigger — so categories appear as they are assigned instead of on
 the next reload. The counter only advances when a report says transactions
@@ -244,9 +244,17 @@ The browser connects once to `GET /api/events` and receives scraping progress,
 completion and error notifications live, along with categorisation progress.
 
 Named events are only delivered to listeners registered for that exact name, so
-`useSSE` keeps the list of subscribed events in `SSE_EVENT_TYPES`. An event the
-server emits but that list omits is dropped silently at both ends — adding an
-emit means adding its name there too.
+`useSSE` keeps the list the client subscribes to in `SSE_EVENT_TYPES`. That list
+is not a catalogue of everything the server emits — `connection:established` and
+`account:sync-completed` go out without appearing in it, because nothing in the
+UI acts on them. But an event outside the list is dropped silently at both ends,
+so a feature reacting to a server event must add its name there as well as write
+the handler; the handler alone will never run.
+
+Each `useSSE` call opens its own `EventSource`. Only one caller is ever mounted
+today (`useOnboarding` on `/onboarding`, `CategorizationProvider` on `/`, which
+are sibling routes), so anything else wanting events app-wide should subscribe
+through a provider that already holds a connection rather than opening a second.
 
 `EventSource` cannot set an `Authorization` header, so the stream authenticates
 with the same httpOnly session cookie as every other route — the client opts in

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { BudgetProvider } from './contexts/BudgetContext';
 import { RSUProvider } from './contexts/RSUContext';
 import { InvestmentProvider } from './contexts/InvestmentContext';
 import { ProjectProvider } from './contexts/ProjectContext';
+import { CategorizationProvider } from './contexts/CategorizationContext';
 import LoginForm from './components/auth/LoginForm';
 import AuthLayout from './components/layout/AuthLayout';
 import ProtectedRoute from './components/auth/ProtectedRoute';
@@ -55,15 +56,17 @@ const App: React.FC = () => {
               path="/"
               element={
                 <ProtectedRoute>
-                  <BudgetProvider>
-                    <RSUProvider>
-                      <InvestmentProvider>
-                        <ProjectProvider>
-                          <AuthLayout />
-                        </ProjectProvider>
-                      </InvestmentProvider>
-                    </RSUProvider>
-                  </BudgetProvider>
+                  <CategorizationProvider>
+                    <BudgetProvider>
+                      <RSUProvider>
+                        <InvestmentProvider>
+                          <ProjectProvider>
+                            <AuthLayout />
+                          </ProjectProvider>
+                        </InvestmentProvider>
+                      </RSUProvider>
+                    </BudgetProvider>
+                  </CategorizationProvider>
                 </ProtectedRoute>
               }
             >

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -20,6 +20,7 @@ import {
   LightMode as LightModeIcon
 } from '@mui/icons-material';
 import { NavigationMenu } from './NavigationMenu';
+import CategorizationStatus from '../transactions/CategorizationStatus';
 import { useAuth } from '../../contexts/AuthContext';
 import { useThemeMode } from '../../contexts/ThemeContext';
 
@@ -146,6 +147,7 @@ const AuthLayout: React.FC = () => {
       </Drawer>
 
       <Container component="main" sx={{ flex: 1, py: 4 }}>
+        <CategorizationStatus />
         <Outlet />
       </Container>
 

--- a/frontend/src/components/transactions/CategorizationStatus.tsx
+++ b/frontend/src/components/transactions/CategorizationStatus.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect } from 'react';
+import { Alert, AlertTitle, Box, LinearProgress, Typography } from '@mui/material';
+import { AutoAwesome as CategorizingIcon } from '@mui/icons-material';
+import { useCategorization } from '../../contexts/CategorizationContext';
+
+const DISMISS_AFTER_MS = 8000;
+
+/**
+ * Tells the user that freshly imported transactions are still being
+ * categorised, so a list that looks half empty reads as work in progress
+ * rather than as a sync that quietly went wrong.
+ */
+export const CategorizationStatus: React.FC = () => {
+  const { active, processed, total, categorized, finished, dismiss } = useCategorization();
+
+  useEffect(() => {
+    if (!finished) return;
+    const timer = setTimeout(dismiss, DISMISS_AFTER_MS);
+    return () => clearTimeout(timer);
+  }, [finished, dismiss]);
+
+  if (active) {
+    // A batch of unknown size would give a bar that fills and resets, which
+    // reads as a stall. An indeterminate bar is honest about not knowing.
+    const percent = total > 0 ? Math.round((processed / total) * 100) : undefined;
+
+    return (
+      <Box sx={{ mb: 2 }} data-testid="categorization-status">
+        <Alert severity="info" icon={<CategorizingIcon />}>
+          <AlertTitle>Categorising your transactions</AlertTitle>
+          <Typography variant="body2" color="text.secondary">
+            {total > 0
+              ? `${processed} of ${total} looked at, ${categorized} categorised so far.`
+              : 'Working through the transactions that just came in.'}
+          </Typography>
+          <LinearProgress
+            variant={percent === undefined ? 'indeterminate' : 'determinate'}
+            value={percent}
+            data-testid="categorization-progress"
+            sx={{ mt: 1, borderRadius: 1 }}
+          />
+        </Alert>
+      </Box>
+    );
+  }
+
+  // Nothing to report: render nothing at all rather than an empty wrapper, since
+  // this sits above every page in the app.
+  if (!finished) return null;
+
+  const needsAttention = finished.uncategorized + finished.failed;
+
+  return (
+    <Box sx={{ mb: 2 }} data-testid="categorization-status">
+      <Alert severity="success" onClose={dismiss}>
+        <AlertTitle>
+          Categorised {finished.categorized} of {finished.total} new transactions
+        </AlertTitle>
+        <Typography variant="body2" color="text.secondary">
+          {needsAttention > 0
+            ? `${needsAttention} still need a category - open them to tell us where they belong, and we will recognise them next time.`
+            : 'Everything that came in has a category.'}
+        </Typography>
+      </Alert>
+    </Box>
+  );
+};
+
+export default CategorizationStatus;

--- a/frontend/src/components/transactions/TransactionTabs.tsx
+++ b/frontend/src/components/transactions/TransactionTabs.tsx
@@ -25,6 +25,7 @@ import {
   Settings as BankManagementIcon
 } from '@mui/icons-material';
 import { useStringParam } from '../../hooks/useUrlParams';
+import { useCategorization } from '../../contexts/CategorizationContext';
 
 // Import existing components
 import { BankAccountsList } from '../bank/BankAccountsList';
@@ -166,6 +167,9 @@ const AllTransactionsView: React.FC = () => {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  // Categorisation happens on a queue after the rows are already saved, so
+  // without this the categories it assigns only appear on the next reload.
+  const { revision } = useCategorization();
 
   const updateFilters = (newFilters: Partial<TransactionFilters>) => {
     setFilters(prev => ({ ...prev, ...newFilters }));
@@ -220,7 +224,7 @@ const AllTransactionsView: React.FC = () => {
       <TransactionsList 
         filters={filters} 
         onRowClick={handleTransactionClick}
-        refreshTrigger={refreshTrigger}
+        refreshTrigger={refreshTrigger + revision}
       />
 
       <TransactionDetailDialog

--- a/frontend/src/components/transactions/__tests__/CategorizationStatus.test.tsx
+++ b/frontend/src/components/transactions/__tests__/CategorizationStatus.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CategorizationStatus from '../CategorizationStatus';
+import { CategorizationProvider } from '../../../contexts/CategorizationContext';
+import { useSSE, SSEEvent } from '../../../hooks/useSSE';
+
+// The hook is mocked globally in setupTests; here we take hold of the handler
+// it is given so a test can push events through the real provider. That way the
+// event names in this file have to match the ones the server sends, rather than
+// being asserted against a hand-written stub of our own state.
+let emit: (event: SSEEvent) => void;
+
+const send = (type: string, data: Record<string, number>) => {
+  act(() => {
+    emit({ type, data, timestamp: new Date().toISOString() });
+  });
+};
+
+const renderStatus = () =>
+  render(
+    <CategorizationProvider>
+      <CategorizationStatus />
+    </CategorizationProvider>
+  );
+
+describe('CategorizationStatus', () => {
+  beforeEach(() => {
+    emit = () => {};
+    (useSSE as jest.Mock).mockImplementation((onEvent: (event: SSEEvent) => void) => {
+      if (onEvent) emit = onEvent;
+      return { connected: true, error: null, lastEvent: null, connect: jest.fn(), disconnect: jest.fn() };
+    });
+  });
+
+  it('stays out of the way when nothing is being categorised', () => {
+    renderStatus();
+
+    expect(screen.queryByTestId('categorization-status')).not.toBeInTheDocument();
+  });
+
+  it('reports how far along a running batch is', () => {
+    renderStatus();
+
+    send('categorization:progress', { processed: 10, total: 40, categorized: 7, uncategorized: 3, failed: 0 });
+
+    expect(screen.getByText(/Categorising your transactions/i)).toBeInTheDocument();
+    expect(screen.getByText(/10 of 40 looked at, 7 categorised so far/i)).toBeInTheDocument();
+    expect(screen.getByTestId('categorization-progress')).toHaveAttribute('aria-valuenow', '25');
+  });
+
+  it('summarises the batch once it finishes', () => {
+    renderStatus();
+
+    send('categorization:progress', { processed: 40, total: 40, categorized: 30, uncategorized: 10, failed: 0 });
+    send('categorization:complete', { total: 40, categorized: 30, uncategorized: 10, failed: 0 });
+
+    expect(screen.getByText(/Categorised 30 of 40 new transactions/i)).toBeInTheDocument();
+    expect(screen.getByText(/10 still need a category/i)).toBeInTheDocument();
+  });
+
+  it('says so when nothing was left over', () => {
+    renderStatus();
+
+    send('categorization:complete', { total: 5, categorized: 5, uncategorized: 0, failed: 0 });
+
+    expect(screen.getByText(/Everything that came in has a category/i)).toBeInTheDocument();
+  });
+
+  it('counts transactions that failed as still needing attention', () => {
+    renderStatus();
+
+    send('categorization:complete', { total: 5, categorized: 3, uncategorized: 1, failed: 1 });
+
+    expect(screen.getByText(/2 still need a category/i)).toBeInTheDocument();
+  });
+
+  it('can be dismissed', async () => {
+    const user = userEvent.setup();
+    renderStatus();
+
+    send('categorization:complete', { total: 5, categorized: 5, uncategorized: 0, failed: 0 });
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(screen.queryByText(/Categorised 5 of 5/i)).not.toBeInTheDocument();
+  });
+
+  it('pays no attention to the other events on the stream', () => {
+    renderStatus();
+
+    send('scraping:completed', { transactionsImported: 40 });
+    send('heartbeat', {});
+
+    expect(screen.queryByTestId('categorization-status')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/transactions/__tests__/CategorizationStatus.test.tsx
+++ b/frontend/src/components/transactions/__tests__/CategorizationStatus.test.tsx
@@ -53,7 +53,7 @@ describe('CategorizationStatus', () => {
     renderStatus();
 
     send('categorization:progress', { processed: 40, total: 40, categorized: 30, uncategorized: 10, failed: 0 });
-    send('categorization:complete', { total: 40, categorized: 30, uncategorized: 10, failed: 0 });
+    send('categorization:completed', { total: 40, categorized: 30, uncategorized: 10, failed: 0 });
 
     expect(screen.getByText(/Categorised 30 of 40 new transactions/i)).toBeInTheDocument();
     expect(screen.getByText(/10 still need a category/i)).toBeInTheDocument();
@@ -62,7 +62,7 @@ describe('CategorizationStatus', () => {
   it('says so when nothing was left over', () => {
     renderStatus();
 
-    send('categorization:complete', { total: 5, categorized: 5, uncategorized: 0, failed: 0 });
+    send('categorization:completed', { total: 5, categorized: 5, uncategorized: 0, failed: 0 });
 
     expect(screen.getByText(/Everything that came in has a category/i)).toBeInTheDocument();
   });
@@ -70,7 +70,7 @@ describe('CategorizationStatus', () => {
   it('counts transactions that failed as still needing attention', () => {
     renderStatus();
 
-    send('categorization:complete', { total: 5, categorized: 3, uncategorized: 1, failed: 1 });
+    send('categorization:completed', { total: 5, categorized: 3, uncategorized: 1, failed: 1 });
 
     expect(screen.getByText(/2 still need a category/i)).toBeInTheDocument();
   });
@@ -79,7 +79,7 @@ describe('CategorizationStatus', () => {
     const user = userEvent.setup();
     renderStatus();
 
-    send('categorization:complete', { total: 5, categorized: 5, uncategorized: 0, failed: 0 });
+    send('categorization:completed', { total: 5, categorized: 5, uncategorized: 0, failed: 0 });
     await user.click(screen.getByRole('button', { name: /close/i }));
 
     expect(screen.queryByText(/Categorised 5 of 5/i)).not.toBeInTheDocument();

--- a/frontend/src/contexts/CategorizationContext.tsx
+++ b/frontend/src/contexts/CategorizationContext.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useCallback, useContext, useMemo, useReducer } from 'react';
+import { useSSE, SSEEvent } from '../hooks/useSSE';
+import {
+  CategorizationState,
+  initialCategorizationState,
+  isCategorizationEvent,
+  reduceCategorization
+} from './categorizationState';
+
+interface CategorizationContextValue extends CategorizationState {
+  dismiss: () => void;
+}
+
+/**
+ * Categorisation runs on a queue after a scrape has already saved the
+ * transactions, so the rows land on screen without a category and only gain one
+ * some seconds later. Nothing in the browser was listening for that, which left
+ * a freshly synced account looking entirely uncategorised until the user
+ * happened to reload.
+ *
+ * The default value is a quiet, idle state rather than a thrown error: this only
+ * ever drives an optional notice and a list refresh, so a subtree rendered
+ * outside the provider should stay silent rather than take the page down.
+ */
+const CategorizationContext = createContext<CategorizationContextValue>({
+  ...initialCategorizationState,
+  dismiss: () => {}
+});
+
+export const CategorizationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reduceCategorization, initialCategorizationState);
+
+  // useSSE tears down and reopens the stream whenever this changes identity, so
+  // it must not depend on the state it updates.
+  const handleEvent = useCallback((event: SSEEvent) => {
+    if (isCategorizationEvent(event.type)) {
+      dispatch({ type: event.type, data: event.data ?? {} });
+    }
+  }, []);
+
+  useSSE(handleEvent, { autoConnect: true });
+
+  const dismiss = useCallback(() => dispatch({ type: 'dismiss' }), []);
+
+  const value = useMemo(() => ({ ...state, dismiss }), [state, dismiss]);
+
+  return <CategorizationContext.Provider value={value}>{children}</CategorizationContext.Provider>;
+};
+
+export const useCategorization = (): CategorizationContextValue => useContext(CategorizationContext);

--- a/frontend/src/contexts/__tests__/categorizationState.test.ts
+++ b/frontend/src/contexts/__tests__/categorizationState.test.ts
@@ -19,7 +19,7 @@ const progress = (data: Record<string, number>): CategorizationEvent => ({
 });
 
 const complete = (data: Record<string, number>): CategorizationEvent => ({
-  type: 'categorization:complete',
+  type: 'categorization:completed',
   data
 });
 

--- a/frontend/src/contexts/__tests__/categorizationState.test.ts
+++ b/frontend/src/contexts/__tests__/categorizationState.test.ts
@@ -1,0 +1,158 @@
+import {
+  CategorizationEvent,
+  CategorizationState,
+  CATEGORIZATION_EVENTS,
+  initialCategorizationState,
+  reduceCategorization
+} from '../categorizationState';
+
+// setupTests replaces the whole useSSE module with a stub of the hook, so the
+// real registry has to be reached past it.
+const { SSE_EVENT_TYPES } = jest.requireActual<typeof import('../../hooks/useSSE')>('../../hooks/useSSE');
+
+const run = (events: CategorizationEvent[], from: CategorizationState = initialCategorizationState) =>
+  events.reduce(reduceCategorization, from);
+
+const progress = (data: Record<string, number>): CategorizationEvent => ({
+  type: 'categorization:progress',
+  data
+});
+
+const complete = (data: Record<string, number>): CategorizationEvent => ({
+  type: 'categorization:complete',
+  data
+});
+
+describe('reduceCategorization', () => {
+  it('starts out with nothing to say', () => {
+    expect(initialCategorizationState.active).toBe(false);
+    expect(initialCategorizationState.finished).toBeNull();
+    expect(initialCategorizationState.revision).toBe(0);
+  });
+
+  it('marks a batch as running while progress arrives', () => {
+    const state = run([progress({ processed: 10, total: 40, categorized: 7, uncategorized: 3, failed: 0 })]);
+
+    expect(state.active).toBe(true);
+    expect(state).toMatchObject({ processed: 10, total: 40, categorized: 7, uncategorized: 3 });
+    expect(state.finished).toBeNull();
+  });
+
+  it('stops being active once the batch completes', () => {
+    const state = run([
+      progress({ processed: 40, total: 40, categorized: 30, uncategorized: 10, failed: 0 }),
+      complete({ total: 40, categorized: 30, uncategorized: 10, failed: 0 })
+    ]);
+
+    expect(state.active).toBe(false);
+    expect(state.finished).toEqual({ total: 40, categorized: 30, uncategorized: 10, failed: 0 });
+  });
+
+  describe('revision', () => {
+    // The revision is a list refresh in disguise, so every assertion here is
+    // really about how many times the transactions list refetches.
+    it('advances when transactions have gained a category', () => {
+      const state = run([progress({ processed: 10, total: 40, categorized: 7 })]);
+      expect(state.revision).toBe(1);
+    });
+
+    it('stays put when a report brings no new categories', () => {
+      const after = run([
+        progress({ processed: 10, total: 40, categorized: 7 }),
+        progress({ processed: 20, total: 40, categorized: 7 })
+      ]);
+
+      expect(after.revision).toBe(1);
+    });
+
+    it('does not advance again on completion when the last report already covered it', () => {
+      const state = run([
+        progress({ processed: 40, total: 40, categorized: 30 }),
+        complete({ total: 40, categorized: 30 })
+      ]);
+
+      expect(state.revision).toBe(1);
+    });
+
+    // A tab opened while the queue was already running, or one whose stream
+    // dropped and reconnected, sees only the completion. It still has a stale
+    // list on screen.
+    it('advances on a completion for a batch it never saw running', () => {
+      const state = run([complete({ total: 40, categorized: 30 })]);
+      expect(state.revision).toBe(1);
+    });
+
+    it('ignores a batch that categorised nothing', () => {
+      const state = run([
+        progress({ processed: 5, total: 5, categorized: 0, uncategorized: 5 }),
+        complete({ total: 5, categorized: 0, uncategorized: 5 })
+      ]);
+
+      expect(state.revision).toBe(0);
+    });
+  });
+
+  // A checking account and the credit cards that pay it off are scraped as
+  // separate jobs, so a second batch follows the first within seconds.
+  describe('a second batch', () => {
+    const firstBatch = run([
+      progress({ processed: 40, total: 40, categorized: 30, uncategorized: 10 }),
+      complete({ total: 40, categorized: 30, uncategorized: 10 })
+    ]);
+
+    it('reports its own totals rather than continuing the previous ones', () => {
+      const state = reduceCategorization(
+        firstBatch,
+        progress({ processed: 2, total: 12, categorized: 1, uncategorized: 1 })
+      );
+
+      expect(state).toMatchObject({ processed: 2, total: 12, categorized: 1, uncategorized: 1 });
+    });
+
+    it('still refreshes the list even though it has categorised fewer than the last', () => {
+      const state = reduceCategorization(firstBatch, progress({ processed: 2, total: 12, categorized: 1 }));
+
+      expect(state.revision).toBe(firstBatch.revision + 1);
+    });
+
+    it('clears the previous batch\'s summary while it runs', () => {
+      const state = reduceCategorization(firstBatch, progress({ processed: 2, total: 12, categorized: 1 }));
+
+      expect(firstBatch.finished).not.toBeNull();
+      expect(state.finished).toBeNull();
+    });
+  });
+
+  it('says nothing about an empty batch', () => {
+    const state = run([complete({ total: 0, categorized: 0, uncategorized: 0, failed: 0 })]);
+
+    expect(state.finished).toBeNull();
+    expect(state.revision).toBe(0);
+  });
+
+  it('survives a report with fields missing', () => {
+    const state = run([progress({}), complete({})]);
+
+    expect(state).toMatchObject({ processed: 0, total: 0, categorized: 0 });
+    expect(state.finished).toBeNull();
+  });
+
+  it('drops the summary when dismissed', () => {
+    const state = run([
+      progress({ processed: 1, total: 1, categorized: 1 }),
+      complete({ total: 1, categorized: 1 }),
+      { type: 'dismiss' }
+    ]);
+
+    expect(state.finished).toBeNull();
+    expect(state.revision).toBe(1);
+  });
+
+  // An event the stream does not subscribe to is dropped by EventSource before
+  // any of this runs, and nothing anywhere reports that it happened.
+  it('is driven by events the stream actually subscribes to', () => {
+    CATEGORIZATION_EVENTS.forEach((eventType) => {
+      expect(SSE_EVENT_TYPES).toContain(eventType);
+    });
+  });
+});

--- a/frontend/src/contexts/categorizationState.ts
+++ b/frontend/src/contexts/categorizationState.ts
@@ -44,11 +44,11 @@ export const initialCategorizationState: CategorizationState = {
 
 export type CategorizationEvent =
   | { type: 'categorization:progress'; data: Partial<CategorizationSummary & { processed: number }> }
-  | { type: 'categorization:complete'; data: Partial<CategorizationSummary> }
+  | { type: 'categorization:completed'; data: Partial<CategorizationSummary> }
   | { type: 'dismiss' };
 
 /** The events this state is driven by, as the server names them on the stream. */
-export const CATEGORIZATION_EVENTS = ['categorization:progress', 'categorization:complete'] as const;
+export const CATEGORIZATION_EVENTS = ['categorization:progress', 'categorization:completed'] as const;
 
 export type CategorizationEventType = (typeof CATEGORIZATION_EVENTS)[number];
 
@@ -86,7 +86,7 @@ export const reduceCategorization = (
       };
     }
 
-    case 'categorization:complete': {
+    case 'categorization:completed': {
       const total = count(event.data.total);
       const categorized = count(event.data.categorized);
       const summary: CategorizationSummary = {

--- a/frontend/src/contexts/categorizationState.ts
+++ b/frontend/src/contexts/categorizationState.ts
@@ -1,0 +1,122 @@
+/**
+ * The state behind the "we are categorising your transactions" indicator.
+ *
+ * Kept as a plain reducer, away from the SSE plumbing, because the interesting
+ * behaviour here is not the transport - it is deciding when a batch has started,
+ * when the categories on the server have actually changed, and when there is
+ * something worth telling the user. All of that is exercised directly in tests
+ * without standing up an EventSource.
+ */
+
+export interface CategorizationSummary {
+  total: number;
+  categorized: number;
+  uncategorized: number;
+  failed: number;
+}
+
+export interface CategorizationState extends CategorizationSummary {
+  /** A batch is being worked on right now. */
+  active: boolean;
+  processed: number;
+  /** The result of the batch that just finished, or null while idle or running. */
+  finished: CategorizationSummary | null;
+  /**
+   * Bumped whenever transactions on the server have gained a category. Lists
+   * pass this straight through as their refresh trigger, so it must only move
+   * when a refetch would actually show something new - a scrape of a few
+   * hundred transactions reports progress every ten of them, and refetching on
+   * each one would put the list through dozens of pointless round trips.
+   */
+  revision: number;
+}
+
+export const initialCategorizationState: CategorizationState = {
+  active: false,
+  processed: 0,
+  total: 0,
+  categorized: 0,
+  uncategorized: 0,
+  failed: 0,
+  finished: null,
+  revision: 0
+};
+
+export type CategorizationEvent =
+  | { type: 'categorization:progress'; data: Partial<CategorizationSummary & { processed: number }> }
+  | { type: 'categorization:complete'; data: Partial<CategorizationSummary> }
+  | { type: 'dismiss' };
+
+/** The events this state is driven by, as the server names them on the stream. */
+export const CATEGORIZATION_EVENTS = ['categorization:progress', 'categorization:complete'] as const;
+
+export type CategorizationEventType = (typeof CATEGORIZATION_EVENTS)[number];
+
+const isCategorizationEvent = (type: string): type is CategorizationEventType =>
+  (CATEGORIZATION_EVENTS as readonly string[]).includes(type);
+
+export { isCategorizationEvent };
+
+const count = (value: unknown): number => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+
+export const reduceCategorization = (
+  state: CategorizationState,
+  event: CategorizationEvent
+): CategorizationState => {
+  switch (event.type) {
+    case 'categorization:progress': {
+      const processed = count(event.data.processed);
+      const categorized = count(event.data.categorized);
+
+      // Two batches can run back to back - a checking account and then the
+      // credit cards it pays off. Counters that only ever climb would show the
+      // second batch continuing the first one's totals.
+      const isNewBatch = !state.active || processed < state.processed;
+      const previouslyCategorized = isNewBatch ? 0 : state.categorized;
+
+      return {
+        active: true,
+        processed,
+        total: count(event.data.total),
+        categorized,
+        uncategorized: count(event.data.uncategorized),
+        failed: count(event.data.failed),
+        finished: null,
+        revision: categorized > previouslyCategorized ? state.revision + 1 : state.revision
+      };
+    }
+
+    case 'categorization:complete': {
+      const total = count(event.data.total);
+      const categorized = count(event.data.categorized);
+      const summary: CategorizationSummary = {
+        total,
+        categorized,
+        uncategorized: count(event.data.uncategorized),
+        failed: count(event.data.failed)
+      };
+
+      return {
+        ...summary,
+        active: false,
+        processed: total,
+        // An empty batch is the queue draining, not news. Saying so would put a
+        // notice on screen that the user cannot act on and did not ask for.
+        finished: total > 0 ? summary : null,
+        // Normally the last progress report has already accounted for these, so
+        // only a batch we never saw running - a tab opened mid-job, a dropped
+        // connection - still owes the list a refresh.
+        revision:
+          categorized > 0 && (!state.active || categorized > state.categorized)
+            ? state.revision + 1
+            : state.revision
+      };
+    }
+
+    case 'dismiss':
+      return { ...state, finished: null };
+
+    default:
+      return state;
+  }
+};

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,6 +1,27 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 
+/**
+ * Every event the stream will deliver to listeners.
+ *
+ * EventSource only invokes handlers registered for an exact event name and does
+ * not fall back to onmessage for named events, so an event missing from this
+ * list is not merely unhandled - it is discarded without a trace on either end.
+ * Adding an emit on the server therefore means adding its name here too.
+ */
+export const SSE_EVENT_TYPES = [
+  'connected',
+  'heartbeat',
+  'scraping:started',
+  'scraping:progress',
+  'scraping:completed',
+  'scraping:failed',
+  'onboarding:credit-card-detection',
+  'onboarding:credit-card-matching',
+  'categorization:progress',
+  'categorization:complete'
+] as const;
+
 export interface SSEEvent {
   type: string;
   data: any;
@@ -136,16 +157,7 @@ export const useSSE = (
 
       // Listen for specific event types
       // The EventSource will automatically call these when events with matching names are received
-      const eventTypes = [
-        'connected',
-        'heartbeat',
-        'scraping:started',
-        'scraping:progress',
-        'scraping:completed',
-        'scraping:failed',
-        'onboarding:credit-card-detection',
-        'onboarding:credit-card-matching'
-      ];
+      const eventTypes = SSE_EVENT_TYPES;
 
       eventTypes.forEach((eventType) => {
         eventSource.addEventListener(eventType, (e: MessageEvent) => {

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -2,12 +2,16 @@ import { useEffect, useCallback, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 
 /**
- * Every event the stream will deliver to listeners.
+ * The named events this client subscribes to.
  *
- * EventSource only invokes handlers registered for an exact event name and does
- * not fall back to onmessage for named events, so an event missing from this
- * list is not merely unhandled - it is discarded without a trace on either end.
- * Adding an emit on the server therefore means adding its name here too.
+ * Not a catalogue of everything the server emits - `connection:established` and
+ * `account:sync-completed` go out on the stream without appearing here, because
+ * nothing in the UI acts on them. What it does mean is that an event outside
+ * this list is discarded by the browser without a trace on either end, since
+ * EventSource only invokes listeners registered for an exact event name and
+ * named events do not fall through to `onmessage`. So a feature that needs to
+ * react to a server event has to add its name here as well as write the handler;
+ * the handler alone will simply never run.
  */
 export const SSE_EVENT_TYPES = [
   'connected',
@@ -19,7 +23,7 @@ export const SSE_EVENT_TYPES = [
   'onboarding:credit-card-detection',
   'onboarding:credit-card-matching',
   'categorization:progress',
-  'categorization:complete'
+  'categorization:completed'
 ] as const;
 
 export interface SSEEvent {
@@ -45,8 +49,19 @@ export interface UseSSEResult {
 /**
  * Generic hook for Server-Sent Events (SSE) connections
  * Provides real-time event streaming from the server
- * 
- * @param onEvent - Callback function called when events are received
+ *
+ * Each call opens its own `EventSource`, so two callers mounted at the same time
+ * mean two connections per tab and the server fanning every event out twice.
+ * That does not happen today - the only two callers are `useOnboarding`, reached
+ * solely from the `/onboarding` route, and `CategorizationProvider`, which wraps
+ * the `/` route; they are sibling routes, so only one is ever mounted. Anything
+ * new that wants events app-wide should subscribe through a provider that
+ * already holds a connection rather than calling this a second time, until the
+ * hook is reworked into a shared multiplexer.
+ *
+ * @param onEvent - Callback function called when events are received. It must be
+ *   referentially stable (`useCallback` with stable deps), because a new
+ *   identity tears the stream down and reopens it.
  * @param options - Configuration options
  * @returns Connection state and control functions
  * 

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -19,6 +19,7 @@ import FilterPanel from '../components/transactions/FilterPanel';
 import TransactionDetailDialog from '../components/transactions/TransactionDetailDialog';
 import { TransactionFilters } from '../services/api/types';
 import type { Transaction } from '../services/api/types/transactions';
+import { useCategorization } from '../contexts/CategorizationContext';
 
 const defaultFilters: Partial<TransactionFilters> = {
   startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // Last 30 days
@@ -44,6 +45,9 @@ const TransactionsPage: React.FC = () => {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  // This view is the list of transactions still waiting for a category, so it
+  // is the one that should visibly shrink while the queue works through them.
+  const { revision } = useCategorization();
 
   // Check if we're showing uncategorized transactions (legacy URL support)
   const isShowingUncategorized = filters.category === 'uncategorized';
@@ -123,7 +127,7 @@ const TransactionsPage: React.FC = () => {
         <TransactionsList 
           filters={filters} 
           onRowClick={handleTransactionClick}
-          refreshTrigger={refreshTrigger}
+          refreshTrigger={refreshTrigger + revision}
         />
 
         {/* Transaction Detail Dialog */}


### PR DESCRIPTION
## What

Categorisation runs on a queue after the scrape has already saved the transactions ([#75](https://github.com/geriamir/gerifinancial/pull/75)), so rows reach the browser before they have a category. The worker was already reporting progress over SSE — nothing in the frontend listened, so a freshly synced account looked entirely uncategorised until the user happened to reload.

Now the transactions list fills in as categories are assigned, with a notice above it saying what is happening.

## The events could not have arrived anyway

`EventSource` only invokes listeners registered for an **exact** event name, and named events do not fall through to `onmessage`. `useSSE` keeps a hard-coded list of subscribed events, and the categorisation ones were never added — so they were dropped in the browser with no error on either end.

That list is now an exported `SSE_EVENT_TYPES` carrying a note about the failure mode, and a test pins that every event the categorisation state is driven by appears in it. Mutation-checked: removing `categorization:progress` from the list fails that test.

## Refreshing without hammering the API

`CategorizationProvider` follows the batch and hands the transaction lists a `revision` counter, which they pass straight through as the `refreshTrigger` the list already supports.

The counter only advances when a report says transactions **actually gained a category**. Progress is emitted every ten transactions, so advancing it unconditionally would turn a scrape of a few hundred into dozens of pointless refetches.

Two batches back to back — a checking account, then the credit cards that pay it off — are told apart, so the second does not continue the first one's totals and still triggers a refresh even though it has categorised fewer than the batch before it. A completion for a batch that was never seen running (a tab opened mid-job, a dropped stream) also refreshes, since that list is stale.

All of this lives in a plain reducer away from the SSE plumbing, so it is tested directly rather than through a stubbed `EventSource`.

## Server side

- **Renamed** to `categorization:progress` / `categorization:complete`, matching the `scraping:` and `onboarding:` names already on the stream. Nothing consumed the old ones, so the contract is settled before it has a consumer.
- **Addressed to the string form of the user id.** Clients are keyed that way and every other emitter already converts — an ObjectId here would have matched no client and been dropped with only a warning in the log.
- **Progress no longer depends on a queue job being present.** The job is how the queue tracks the work; whether the person waiting is told how far along it is has nothing to do with that. Caught by a new test that calls `processBatch` the way a non-queue caller would and got no progress event at all.

## Notes

- The provider sits inside `ProtectedRoute` and the notice renders in `AuthLayout`, so it is visible wherever the user happens to be when a sync finishes — not only on the transactions page.
- The context default is a quiet idle state rather than a thrown error. This drives an optional notice and a list refresh; a subtree rendered outside the provider should stay silent rather than take the page down. `AuthLayout`'s existing test renders it with no provider and still passes.

## Verification

- `tsc --noEmit`, `eslint --max-warnings 0` — clean
- frontend jest: **252 passed** (230 before, 22 new)
- backend `banking/services`: **198 passed** (12 in the categorisation suite, 3 new)
- Cypress: **29/29 across all 5 specs**, run locally against the production build
- Both behaviours that matter were mutation-checked — reverting each fix fails exactly the intended test with the expected symptom
