### PR TITLE
Give each bank an icon in the selection lists

### DIFF
--- a/frontend/src/components/bank/BankAccountForm.tsx
+++ b/frontend/src/components/bank/BankAccountForm.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import { bankAccountsApi } from '../../services/api/bank';
 import { SUPPORTED_BANKS, isApiBank, isOtpBank } from '../../constants/banks';
+import { BankIcon } from './BankIcon';
 import { track } from '../../utils/analytics';
 import { BANK_ACCOUNT_EVENTS } from '../../constants/analytics';
 
@@ -152,9 +153,11 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
               value={formData.bankId}
               onChange={handleSelectChange}
               required
+              sx={{ '& .MuiSelect-select': { display: 'flex', alignItems: 'center', gap: 1.5 } }}
             >
               {SUPPORTED_BANKS.map(bank => (
-                <MenuItem key={bank.id} value={bank.id}>
+                <MenuItem key={bank.id} value={bank.id} sx={{ gap: 1.5 }}>
+                  <BankIcon bankId={bank.id} size={24} />
                   {bank.name}
                 </MenuItem>
               ))}

--- a/frontend/src/components/bank/BankAccountsList.tsx
+++ b/frontend/src/components/bank/BankAccountsList.tsx
@@ -22,7 +22,8 @@ import {
 } from '@mui/icons-material';
 import { bankAccountsApi } from '../../services/api/bank';
 import { BankAccount } from '../../services/api/types';
-import { SUPPORTED_BANKS, getBankStrategies } from '../../constants/banks';
+import { getBankName, getBankStrategies } from '../../constants/banks';
+import { BankIcon } from './BankIcon';
 import { BankAccountForm } from './BankAccountForm';
 import { UpdateCredentialsDialog } from './UpdateCredentialsDialog';
 import { track } from '../../utils/analytics';
@@ -129,11 +130,6 @@ export const BankAccountsList: React.FC = () => {
     setShowUpdateCredentials(true);
   };
 
-  const getBankName = (bankId: string) => {
-    const bank = SUPPORTED_BANKS.find(bank => bank.id === bankId);
-    return bank ? bank.name : bankId;
-  };
-
   if (loading) {
     return <Typography>Loading accounts...</Typography>;
   }
@@ -182,38 +178,41 @@ export const BankAccountsList: React.FC = () => {
                   justifyContent="space-between"
                   alignItems="center"
                 >
-                  <Box>
-                    <Typography variant="h6" sx={{ mb: 0.5 }}>{account.name}</Typography>
-                    <Typography color="textSecondary" variant="body2">
-                      {getBankName(account.bankId)}
-                    </Typography>
-                    {account.currentBalance != null && (
-                      <Typography variant="body1" fontWeight="bold" sx={{ mt: 0.5 }}>
-                        {formatCurrency(account.currentBalance, account.defaultCurrency || 'ILS')}
+                  <Stack direction="row" spacing={2} alignItems="flex-start">
+                    <BankIcon bankId={account.bankId} size={40} sx={{ mt: 0.5, flexShrink: 0 }} />
+                    <Box>
+                      <Typography variant="h6" sx={{ mb: 0.5 }}>{account.name}</Typography>
+                      <Typography color="textSecondary" variant="body2">
+                        {getBankName(account.bankId)}
                       </Typography>
-                    )}
-                    {account.strategySync && Object.entries(account.strategySync)
-                      .filter(([strategy, sync]) => sync?.status === 'failed' && getBankStrategies(account.bankId).includes(strategy))
-                      .map(([strategy]) => (
-                        <Typography key={strategy} color="error" variant="caption" display="block">
-                          {getStrategyDisplayName(strategy)} sync failed
+                      {account.currentBalance != null && (
+                        <Typography variant="body1" fontWeight="bold" sx={{ mt: 0.5 }}>
+                          {formatCurrency(account.currentBalance, account.defaultCurrency || 'ILS')}
                         </Typography>
-                      ))
-                    }
-                    {account.lastError && (
-                      <Typography color="error" variant="caption" display="block" sx={{ mb: 1 }}>
-                        {account.lastError.message}
-                      </Typography>
-                    )}
-                    <AccountScraping
-                      accountId={account._id}
-                      bankId={account.bankId}
-                      lastScraped={account.lastScraped}
-                      strategySync={account.strategySync}
-                      isDisabled={account.status !== 'active'}
-                      onScrapingComplete={fetchAccounts}
-                    />
-                  </Box>
+                      )}
+                      {account.strategySync && Object.entries(account.strategySync)
+                        .filter(([strategy, sync]) => sync?.status === 'failed' && getBankStrategies(account.bankId).includes(strategy))
+                        .map(([strategy]) => (
+                          <Typography key={strategy} color="error" variant="caption" display="block">
+                            {getStrategyDisplayName(strategy)} sync failed
+                          </Typography>
+                        ))
+                      }
+                      {account.lastError && (
+                        <Typography color="error" variant="caption" display="block" sx={{ mb: 1 }}>
+                          {account.lastError.message}
+                        </Typography>
+                      )}
+                      <AccountScraping
+                        accountId={account._id}
+                        bankId={account.bankId}
+                        lastScraped={account.lastScraped}
+                        strategySync={account.strategySync}
+                        isDisabled={account.status !== 'active'}
+                        onScrapingComplete={fetchAccounts}
+                      />
+                    </Box>
+                  </Stack>
                   <Stack direction="row" spacing={1} alignItems="center">
                     <Chip
                       label={account.status}

--- a/frontend/src/components/bank/BankIcon.tsx
+++ b/frontend/src/components/bank/BankIcon.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Avatar, SxProps, Theme } from '@mui/material';
+import { AccountBalance as BankIconFallback } from '@mui/icons-material';
+import { getBank } from '../../constants/banks';
+
+interface BankIconProps {
+  bankId: string;
+  /** Diameter in pixels. 24 suits a dropdown row, 40 a card header. */
+  size?: number;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * The visual identity of one bank.
+ *
+ * No bank logos are bundled with this repository - they are trademarks, and
+ * shipping them is a licensing question rather than a technical one. So the
+ * default mark is the bank's monogram on its own colour, which is enough for
+ * the thing an icon is actually for here: telling four rows of a dropdown apart
+ * at a glance. If a logo file is added and pointed at from `constants/banks.ts`,
+ * MUI's Avatar renders it and falls back to these children on its own when the
+ * image is missing or fails to load, so nothing here has to change.
+ *
+ * An unknown id still renders something. Account rows come from the database and
+ * can outlive a bank being removed from the supported list, and a stored account
+ * that draws nothing at all looks broken.
+ */
+export const BankIcon: React.FC<BankIconProps> = ({ bankId, size = 28, sx }) => {
+  const bank = getBank(bankId);
+
+  return (
+    <Avatar
+      src={bank?.logo}
+      alt=""
+      // The name is always rendered as text next to this, so announcing the
+      // bank again here would just make a screen reader say it twice.
+      aria-hidden
+      data-testid={`bank-icon-${bankId}`}
+      sx={{
+        width: size,
+        height: size,
+        bgcolor: bank?.color ?? 'grey.500',
+        color: '#fff',
+        // Monograms are up to three characters, so they have to shrink faster
+        // than the circle does to keep "CAL" inside it.
+        fontSize: size * 0.36,
+        fontWeight: 600,
+        letterSpacing: 0,
+        ...sx
+      }}
+    >
+      {bank ? bank.monogram : <BankIconFallback sx={{ fontSize: size * 0.6 }} />}
+    </Avatar>
+  );
+};

--- a/frontend/src/components/bank/__tests__/BankIcon.test.tsx
+++ b/frontend/src/components/bank/__tests__/BankIcon.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BankIcon } from '../BankIcon';
+import { SUPPORTED_BANKS, CHECKING_ACCOUNT_BANKS, CREDIT_CARD_PROVIDERS, API_BANKS, OTP_BANKS } from '../../../constants/banks';
+
+describe('BankIcon', () => {
+  it('shows the monogram for a known bank', () => {
+    render(<BankIcon bankId="hapoalim" />);
+    expect(screen.getByTestId('bank-icon-hapoalim')).toHaveTextContent('HP');
+  });
+
+  // Account rows come from the database and can outlive a bank being dropped
+  // from the supported list. Drawing nothing at all there looks broken.
+  it('still renders something for a bank it does not know', () => {
+    render(<BankIcon bankId="some-retired-bank" />);
+    expect(screen.getByTestId('bank-icon-some-retired-bank')).toBeInTheDocument();
+  });
+
+  // The bank name is always rendered as text beside the icon, so announcing it
+  // here as well would just make a screen reader say it twice.
+  it('is hidden from assistive technology', () => {
+    render(<BankIcon bankId="leumi" />);
+    expect(screen.getByTestId('bank-icon-leumi')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  describe('the bank list itself', () => {
+    it('gives every bank a monogram and a colour', () => {
+      for (const bank of SUPPORTED_BANKS) {
+        expect(bank.monogram).toMatch(/^[A-Z]{2,3}$/);
+        expect(bank.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      }
+    });
+
+    // Within a group these are shown as a list of options, so a repeat reads as
+    // a rendering bug rather than as a choice.
+    it.each([
+      ['checking accounts', CHECKING_ACCOUNT_BANKS],
+      ['credit cards', CREDIT_CARD_PROVIDERS],
+      ['API banks', API_BANKS],
+      ['OTP providers', OTP_BANKS]
+    ])('keeps %s telling apart from each other', (_label, group) => {
+      expect(new Set(group.map((bank) => bank.monogram)).size).toBe(group.length);
+      expect(new Set(group.map((bank) => bank.color)).size).toBe(group.length);
+    });
+
+    // No bank logos are bundled - they are trademarks. The monogram is the
+    // default on purpose, and this is the test that notices if one is added.
+    it('ships no logo files, so every bank falls back to its monogram', () => {
+      expect(SUPPORTED_BANKS.filter((bank) => bank.logo)).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/components/onboarding/chat/cards/CheckingAccountCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CheckingAccountCard.tsx
@@ -15,6 +15,7 @@ import {
 import { Lock as LockIcon } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { CHECKING_ACCOUNT_BANKS } from '../../../../constants/banks';
+import { BankIcon } from '../../../bank/BankIcon';
 import { track } from '../../../../utils/analytics';
 import { BANK_ACCOUNT_EVENTS } from '../../../../constants/analytics';
 import { CardShell } from '../CardShell';
@@ -94,9 +95,11 @@ export const CheckingAccountCard: React.FC<CardProps> = ({ handlers }) => {
             onChange={handleSelect}
             label="Your bank"
             data-testid="bank-select"
+            sx={{ '& .MuiSelect-select': { display: 'flex', alignItems: 'center', gap: 1.5 } }}
           >
             {CHECKING_ACCOUNT_BANKS.map((bank) => (
-              <MenuItem key={bank.id} value={bank.id}>
+              <MenuItem key={bank.id} value={bank.id} sx={{ gap: 1.5 }}>
+                <BankIcon bankId={bank.id} size={24} />
                 {bank.name}
               </MenuItem>
             ))}

--- a/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
@@ -15,6 +15,7 @@ import {
 import { Lock as LockIcon } from '@mui/icons-material';
 import { AxiosError } from 'axios';
 import { CREDIT_CARD_PROVIDERS } from '../../../../constants/banks';
+import { BankIcon } from '../../../bank/BankIcon';
 import { CardShell } from '../CardShell';
 import { CardProps } from '../types';
 
@@ -86,9 +87,11 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ handlers }) => {
             onChange={handleSelect}
             label="Card provider"
             data-testid="provider-select"
+            sx={{ '& .MuiSelect-select': { display: 'flex', alignItems: 'center', gap: 1.5 } }}
           >
             {CREDIT_CARD_PROVIDERS.map((provider) => (
-              <MenuItem key={provider.id} value={provider.id}>
+              <MenuItem key={provider.id} value={provider.id} sx={{ gap: 1.5 }}>
+                <BankIcon bankId={provider.id} size={24} />
                 {provider.name}
               </MenuItem>
             ))}

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CheckingAccountCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CheckingAccountCard.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { CheckingAccountCard } from '../CheckingAccountCard';
+import { CHECKING_ACCOUNT_BANKS } from '../../../../../constants/banks';
+import { OnboardingStatus } from '../../../../../services/api/onboarding';
+import { ChatHandlers } from '../../types';
+
+const handlers: ChatHandlers = {
+  connectCheckingAccount: jest.fn().mockResolvedValue(undefined),
+  connectCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  proceedToCreditCardSetup: jest.fn().mockResolvedValue(undefined),
+  skipCreditCards: jest.fn().mockResolvedValue(undefined),
+  completeOnboarding: jest.fn().mockResolvedValue(undefined)
+};
+
+const openBankList = () => {
+  render(<CheckingAccountCard status={{} as OnboardingStatus} handlers={handlers} />);
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+  return within(screen.getByRole('listbox'));
+};
+
+describe('CheckingAccountCard bank selection', () => {
+  it('marks every bank in the list with its own icon', () => {
+    const list = openBankList();
+
+    for (const bank of CHECKING_ACCOUNT_BANKS) {
+      expect(list.getByTestId(`bank-icon-${bank.id}`)).toHaveTextContent(bank.monogram);
+    }
+  });
+
+  it('still names every bank, so the icon is a cue rather than the only label', () => {
+    const list = openBankList();
+
+    for (const bank of CHECKING_ACCOUNT_BANKS) {
+      expect(list.getByText(bank.name)).toBeInTheDocument();
+    }
+  });
+
+  // The whole point of the icon is recognising the account you picked without
+  // reading, so it has to survive into the closed control.
+  it('keeps the icon visible once a bank is chosen', () => {
+    const list = openBankList();
+
+    fireEvent.click(list.getByText('Bank Leumi'));
+
+    expect(within(screen.getByRole('combobox')).getByTestId('bank-icon-leumi')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CheckingAccountCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CheckingAccountCard.test.tsx
@@ -16,7 +16,7 @@ const handlers: ChatHandlers = {
 const openBankList = () => {
   render(<CheckingAccountCard status={{} as OnboardingStatus} handlers={handlers} />);
   fireEvent.mouseDown(screen.getByRole('combobox'));
-  return within(screen.getByRole('listbox'));
+  return screen.getByRole('listbox');
 };
 
 describe('CheckingAccountCard bank selection', () => {
@@ -24,7 +24,7 @@ describe('CheckingAccountCard bank selection', () => {
     const list = openBankList();
 
     for (const bank of CHECKING_ACCOUNT_BANKS) {
-      expect(list.getByTestId(`bank-icon-${bank.id}`)).toHaveTextContent(bank.monogram);
+      expect(within(list).getByTestId(`bank-icon-${bank.id}`)).toHaveTextContent(bank.monogram);
     }
   });
 
@@ -32,7 +32,7 @@ describe('CheckingAccountCard bank selection', () => {
     const list = openBankList();
 
     for (const bank of CHECKING_ACCOUNT_BANKS) {
-      expect(list.getByText(bank.name)).toBeInTheDocument();
+      expect(within(list).getByText(bank.name)).toBeInTheDocument();
     }
   });
 
@@ -41,7 +41,7 @@ describe('CheckingAccountCard bank selection', () => {
   it('keeps the icon visible once a bank is chosen', () => {
     const list = openBankList();
 
-    fireEvent.click(list.getByText('Bank Leumi'));
+    fireEvent.click(within(list).getByText('Bank Leumi'));
 
     expect(within(screen.getByRole('combobox')).getByTestId('bank-icon-leumi')).toBeInTheDocument();
   });

--- a/frontend/src/constants/banks.ts
+++ b/frontend/src/constants/banks.ts
@@ -1,33 +1,50 @@
 export interface SupportedBank {
   id: string;
   name: string;
+  /**
+   * Two or three letters shown when there is no logo file. Unique within a
+   * group, so a list of them reads as distinct options rather than as a
+   * rendering bug.
+   */
+  monogram: string;
+  /** Background the monogram sits on. Chosen per group to stay distinguishable. */
+  color: string;
+  /**
+   * Path to a logo under `public/`, if one has been added. Bank logos are
+   * trademarks and none are bundled with this repository, so this is unset
+   * everywhere by default and the monogram is what renders. Drop a file in
+   * `public/banks/` and point this at it to use the real mark instead - no
+   * component needs to change, because `BankIcon` falls back to the monogram
+   * when the image is missing or fails to load.
+   */
+  logo?: string;
 }
 
 // Checking Account Banks (Primary onboarding focus)
 export const CHECKING_ACCOUNT_BANKS: SupportedBank[] = [
-  { id: 'hapoalim', name: 'Bank Hapoalim' },
-  { id: 'leumi', name: 'Bank Leumi' },
-  { id: 'discount', name: 'Discount Bank' },
-  { id: 'otsarHahayal', name: 'Otsar HaHayal' }
+  { id: 'hapoalim', name: 'Bank Hapoalim', monogram: 'HP', color: '#C8102E' },
+  { id: 'leumi', name: 'Bank Leumi', monogram: 'LM', color: '#1B3A6B' },
+  { id: 'discount', name: 'Discount Bank', monogram: 'DS', color: '#00843D' },
+  { id: 'otsarHahayal', name: 'Otsar HaHayal', monogram: 'OH', color: '#0F7B8A' }
 ];
 
 // Credit Card Providers (Secondary onboarding step)
 export const CREDIT_CARD_PROVIDERS: SupportedBank[] = [
-  { id: 'visaCal', name: 'Visa Cal' },
-  { id: 'max', name: 'Max' },
-  { id: 'isracard', name: 'Isracard' }
+  { id: 'visaCal', name: 'Visa Cal', monogram: 'CAL', color: '#0057B8' },
+  { id: 'max', name: 'Max', monogram: 'MAX', color: '#5B2C86' },
+  { id: 'isracard', name: 'Isracard', monogram: 'ISR', color: '#E4761B' }
 ];
 
 // API-based banks (token-based REST API, no browser scraping)
 export const API_BANKS: SupportedBank[] = [
-  { id: 'mercury', name: 'Mercury' },
-  { id: 'ibkr', name: 'Interactive Brokers' }
+  { id: 'mercury', name: 'Mercury', monogram: 'MC', color: '#5A31F4' },
+  { id: 'ibkr', name: 'Interactive Brokers', monogram: 'IB', color: '#B3202C' }
 ];
 
 // OTP-based banks (browser automation with OTP login)
 export const OTP_BANKS: SupportedBank[] = [
-  { id: 'phoenix', name: 'Phoenix Insurance (הפניקס)' },
-  { id: 'clal', name: 'Clal Insurance (כלל ביטוח)' }
+  { id: 'phoenix', name: 'Phoenix Insurance (הפניקס)', monogram: 'PX', color: '#F26522' },
+  { id: 'clal', name: 'Clal Insurance (כלל ביטוח)', monogram: 'CL', color: '#004B8D' }
 ];
 
 // All supported banks (for backward compatibility)
@@ -87,3 +104,8 @@ export const getBanksByType = (type: 'checking' | 'credit' | 'api' | 'otp'): Sup
   if (type === 'otp') return OTP_BANKS;
   return API_BANKS;
 };
+
+export const getBank = (bankId: string): SupportedBank | undefined =>
+  SUPPORTED_BANKS.find(bank => bank.id === bankId);
+
+export const getBankName = (bankId: string): string => getBank(bankId)?.name ?? bankId;

--- a/frontend/src/pages/Pension.tsx
+++ b/frontend/src/pages/Pension.tsx
@@ -40,7 +40,7 @@ import {
   PRODUCT_TYPE_LABELS,
   PRODUCT_TYPE_COLORS
 } from '../services/api/types/pension';
-import { OTP_BANKS } from '../constants/banks';
+import { isOtpBank } from '../constants/banks';
 
 const formatCurrency = (amount: number | null, currency = 'ILS'): string => {
   if (amount == null) return '—';
@@ -284,7 +284,7 @@ const SyncDialog: React.FC<SyncDialogProps> = ({ open, onClose, onSyncComplete }
     import('../services/api/bank').then(({ bankAccountsApi }) => {
       bankAccountsApi.getAll().then((accounts: any[]) => {
         const otp = accounts.filter((a: any) =>
-          OTP_BANKS.includes(a.bankId) && a.status === 'active'
+          isOtpBank(a.bankId) && a.status === 'active'
         );
         setOtpAccounts(otp);
         if (otp.length === 1) setBankAccountId(otp[0]._id);

--- a/frontend/src/pages/Pension.tsx
+++ b/frontend/src/pages/Pension.tsx
@@ -282,13 +282,16 @@ const SyncDialog: React.FC<SyncDialogProps> = ({ open, onClose, onSyncComplete }
     setBankAccountId('');
 
     import('../services/api/bank').then(({ bankAccountsApi }) => {
-      bankAccountsApi.getAll().then((accounts: any[]) => {
-        const otp = accounts.filter((a: any) =>
-          isOtpBank(a.bankId) && a.status === 'active'
-        );
+      // Left to infer BankAccount[] rather than annotated `any[]`: the previous
+      // annotation is what let `OTP_BANKS.includes(a.bankId)` - a string tested
+      // against an array of bank objects, and so always false - compile and ship.
+      bankAccountsApi.getAll().then((accounts) => {
+        const otp = accounts
+          .filter((account) => isOtpBank(account.bankId) && account.status === 'active')
+          .map(({ _id, bankId, name }) => ({ _id, bankId, name }));
         setOtpAccounts(otp);
         if (otp.length === 1) setBankAccountId(otp[0]._id);
-      }).catch((err: any) => {
+      }).catch((err) => {
         console.error('Failed to load OTP bank accounts', err);
         setError('Failed to load pension provider accounts. Please try again.');
       });


### PR DESCRIPTION
Picking a bank meant reading a dropdown of near-identical text rows, and a connected account showed its provider only as a line of small grey type. Both are recognition tasks that a mark does better than a word.

## What changed

Each bank now carries a monogram and a colour, rendered by a single `BankIcon` component used in all four places a bank appears:

| Where | What it looks like now |
| --- | --- |
| Onboarding — checking account card | icon + name per option, icon stays in the closed control |
| Onboarding — credit card card | same |
| Add account dialog | same, across all 11 supported providers |
| Bank accounts list | 40px icon beside each connected account |

## On logos

**No bank logos are bundled.** They are trademarks, and shipping them is a licensing question rather than a technical one — so the default mark is the bank's monogram on its own colour. That is enough for what the icon is actually for here: telling four rows of a dropdown apart at a glance.

There is a seam for the real thing if you ever want it. Set `logo` on a bank in `constants/banks.ts` and MUI's `Avatar` renders the image, falling back to the monogram on its own if the file is missing or fails to load. No component has to change. A test asserts no logos are currently set, so it will notice when that changes.

Colours are chosen to stay distinct **within each group** — checking banks, credit providers, API banks, OTP providers — rather than across the whole list, because that is how they are shown. A test holds both that and monogram uniqueness per group.

## A bug found next door

The pension OTP dialog filtered accounts with:

```ts
OTP_BANKS.includes(a.bankId)
```

`OTP_BANKS` is an array of bank *objects*; `a.bankId` is a string. This is always false, so the dialog never listed a provider account. `accounts` is typed `any[]`, which is why the compiler never objected. There was already an `isOtpBank` helper for exactly this case, now used.

## Verification

- `tsc --noEmit` clean, `eslint` clean, production build clean
- Frontend jest: **264 passed** across 23 suites (was 261/22 — 12 new)
- New tests cover the icon component, the per-group distinctness of the bank list, and the actual wiring in the checking-account card: every option carries its own icon, every bank is still named in text, and the icon survives into the closed control once chosen
- An unknown `bankId` still renders a generic mark — account rows come from the database and can outlive a bank being dropped from the supported list
- The icon is `aria-hidden`; the bank name is always present as text, so a screen reader says it once
