### PR TITLE
Come back to what the AI budget cut off

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,5 +67,6 @@ AI_LLM_BATCH_SIZE=10
 # How many transactions the model never got to - because the daily budget ran
 # out first - are pulled back into the next scrape's batch, newest first. Sized
 # against what a day's tokens can pay for, not against the backlog: anything
-# beyond that just meets the same spent budget and waits another day.
+# beyond that just meets the same spent budget and waits another day. Set to 0
+# to stop resuming altogether.
 AI_LLM_RESUME_LIMIT=1000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -64,3 +64,8 @@ AI_LLM_MIN_CONFIDENCE=0.7
 # once costs roughly a fifth of the tokens of ten separate calls. Larger batches
 # save a little more, but a reply that gets truncated loses the whole batch.
 AI_LLM_BATCH_SIZE=10
+# How many transactions the model never got to - because the daily budget ran
+# out first - are pulled back into the next scrape's batch, newest first. Sized
+# against what a day's tokens can pay for, not against the backlog: anything
+# beyond that just meets the same spent budget and waits another day.
+AI_LLM_RESUME_LIMIT=1000

--- a/backend/src/banking/models/Transaction.js
+++ b/backend/src/banking/models/Transaction.js
@@ -119,6 +119,18 @@ const transactionSchema = new mongoose.Schema({
     // Stores explanation of why this categorization was chosen
     // e.g., "Matched keyword 'grocery' in description", "AI suggestion based on description pattern"
   },
+  // Set when the model tier was skipped rather than consulted, because the
+  // user's daily AI budget ran out before this transaction's turn.
+  //
+  // Without it, a transaction the model never saw looks exactly like one it saw
+  // and declined: both end with no category. That leaves only two bad options -
+  // abandon everything past the budget cliff, or re-ask about every
+  // unrecognisable description every day for ever. This separates the two, so a
+  // later run can pick up precisely what was missed.
+  awaitingModelCategorization: {
+    type: Boolean,
+    default: false
+  },
   status: {
     type: String,
     enum: Object.values(TransactionStatus),
@@ -212,12 +224,25 @@ transactionSchema.index(
   { partialFilterExpression: { uniqueId: { $type: 'string' } } }
 );
 
+// Only the transactions still owed a look from the model. Partial so the index
+// carries the outstanding few rather than a boolean for every transaction the
+// user has ever had, and so it empties itself as the backlog is worked off.
+transactionSchema.index(
+  { userId: 1, date: -1 },
+  { partialFilterExpression: { awaitingModelCategorization: true } }
+);
+
 // Helper method to categorize a transaction
 transactionSchema.methods.categorize = async function(categoryId, subCategoryId, method = CategorizationMethod.MANUAL, reasoning = null) {
   this.category = categoryId;
   this.subCategory = subCategoryId;
   this.categorizationMethod = method;
   this.categorizationReasoning = reasoning;
+  // Whoever placed it - the user, a cheap tier, or the model itself - there is
+  // nothing left for the model to be asked. Clearing it here rather than at
+  // each call site means no route to a category can leave the transaction
+  // sitting in the resume queue.
+  this.awaitingModelCategorization = false;
   await this.save();
 };
 

--- a/backend/src/banking/services/__tests__/categoryMappingService.test.js
+++ b/backend/src/banking/services/__tests__/categoryMappingService.test.js
@@ -4,6 +4,7 @@ const { Category, SubCategory, Transaction, ManualCategorized } = require('../..
 const { CategorizationMethod, TransactionType } = require('../../constants/enums');
 const llmCategorizer = require('../llmCategorizer');
 const llmService = require('../../../shared/services/ai/llmService');
+const { AiBudgetExceededError } = require('../../../shared/services/ai/aiBudget');
 const config = require('../../../shared/config');
 
 const originalLlmEnabled = config.ai.llm.categorization;
@@ -572,6 +573,104 @@ describe('CategoryMappingService', () => {
           await categoryMappingService.finishDeferred(transaction, catalogue);
 
           expect((await Transaction.findById(transaction._id)).type).toBe(TransactionType.EXPENSE);
+        });
+      });
+
+      // Nothing else ever revisits an uncategorised transaction - the queue is
+      // fed only by newly-saved ones - so whatever the budget cuts off would be
+      // abandoned for good unless it is written down here. The distinction
+      // matters both ways: re-asking about one the model already declined would
+      // spend the same money on the same refusal every single day.
+      describe('recording what the budget cut off', () => {
+        const spendTheBudget = () =>
+          llmService.__setChatError(new AiBudgetExceededError(testUserId, 200000, 200000));
+
+        it('marks a transaction the budget stopped the model from ever seeing', async () => {
+          const transaction = await uncategorisable();
+          const catalogue = await llmCategorizer.forUser(testUserId);
+          spendTheBudget();
+
+          await categoryMappingService.finishDeferred(transaction, catalogue);
+
+          const saved = await Transaction.findById(transaction._id);
+          expect(saved.awaitingModelCategorization).toBe(true);
+          expect(saved.category).toBeFalsy();
+          // Still given everything a settled transaction gets, so the user sees
+          // it in their list rather than it hiding until the model catches up.
+          expect(saved.type).toBe(TransactionType.EXPENSE);
+        });
+
+        it('leaves a transaction the model looked at and declined unmarked', async () => {
+          const transaction = await uncategorisable();
+          const catalogue = await llmCategorizer.forUser(testUserId);
+          llmService.__setChatResponse({ content: JSON.stringify({ category: null, confidence: 0 }) });
+
+          await categoryMappingService.finishDeferred(transaction, catalogue);
+
+          expect((await Transaction.findById(transaction._id)).awaitingModelCategorization).toBe(false);
+        });
+
+        it('clears the mark once the model has finally looked, even if it declines', async () => {
+          const transaction = await uncategorisable({ awaitingModelCategorization: true });
+          const catalogue = await llmCategorizer.forUser(testUserId);
+          llmService.__setChatResponse({ content: JSON.stringify({ category: null, confidence: 0 }) });
+
+          await categoryMappingService.finishDeferred(transaction, catalogue);
+
+          expect((await Transaction.findById(transaction._id)).awaitingModelCategorization).toBe(false);
+        });
+
+        it('clears the mark when the model finally places it', async () => {
+          const transaction = await uncategorisable({ awaitingModelCategorization: true });
+          const catalogue = await llmCategorizer.forUser(testUserId);
+
+          await categoryMappingService.finishDeferred(transaction, catalogue);
+
+          const saved = await Transaction.findById(transaction._id);
+          expect(saved.category).toBeTruthy();
+          expect(saved.awaitingModelCategorization).toBe(false);
+        });
+
+        // A refusal the model already gave is an answer. Once the budget trips
+        // later in the same run, every transaction sharing that description
+        // would otherwise be marked unseen and re-asked on the next run - the
+        // exact daily spend on hopeless descriptions this is meant to avoid.
+        it('leaves one the model already declined alone when the budget trips later', async () => {
+          const first = await uncategorisable({ description: 'מכולת פינתית' });
+          const second = await uncategorisable({ description: 'מכולת פינתית' });
+          const catalogue = await llmCategorizer.forUser(testUserId);
+          llmService.__setChatResponse({ content: JSON.stringify({ category: null, confidence: 0 }) });
+
+          await categoryMappingService.finishDeferred(first, catalogue);
+          spendTheBudget();
+          // Something else in the same run runs the budget out.
+          await categoryMappingService.finishDeferred(await uncategorisable(), catalogue);
+
+          await categoryMappingService.finishDeferred(second, catalogue);
+
+          expect((await Transaction.findById(second._id)).awaitingModelCategorization).toBe(false);
+        });
+
+        // A transaction can also fall off the cliff without a batch around it.
+        it('marks one the budget cut off on the single-call path too', async () => {
+          const transaction = await uncategorisable();
+          spendTheBudget();
+
+          await categoryMappingService.attemptAutoCategorization(transaction);
+
+          expect((await Transaction.findById(transaction._id)).awaitingModelCategorization).toBe(true);
+        });
+
+        // The model being down is not the same as the budget being spent: it
+        // costs nothing, so there is no cliff to resume from, and marking it
+        // would build a backlog that never drains.
+        it('does not mark one the model simply failed to answer', async () => {
+          const transaction = await uncategorisable();
+          llmService.__setChatError(new Error('502 Bad Gateway'));
+
+          await categoryMappingService.attemptAutoCategorization(transaction);
+
+          expect((await Transaction.findById(transaction._id)).awaitingModelCategorization).toBe(false);
         });
       });
 

--- a/backend/src/banking/services/__tests__/llmCategorizer.test.js
+++ b/backend/src/banking/services/__tests__/llmCategorizer.test.js
@@ -339,6 +339,48 @@ describe('llmCategorizer', () => {
       expect(llmService.chat).toHaveBeenCalledTimes(1);
     });
 
+    // Callers use a null from a spent budget to mean "the model never saw this
+    // one, come back to it later". An answer already paid for this run must not
+    // be thrown away and counted as unseen, or a transaction the model has
+    // already judged gets re-asked on every later run for ever.
+    it('still serves an answer it already has after the budget is spent', async () => {
+      await seedCategories();
+      const catalogue = await llmCategorizer.forUser(userId);
+      answering({ category: 'Food', subCategory: 'Groceries', confidence: 0.9 });
+
+      const first = await ask(catalogue);
+      expect(first).not.toBeNull();
+
+      llmService.__setChatError(new AiBudgetExceededError(userId, 200000, 200000));
+      await ask(catalogue, { description: 'something new' });
+      expect(catalogue.budgetExhausted).toBe(true);
+
+      const again = await ask(catalogue);
+      expect(again).not.toBeNull();
+      expect(String(again.categoryId)).toBe(String(first.categoryId));
+    });
+
+    // A refusal is an answer. The caller uses this to tell a transaction the
+    // model declined apart from one it never reached, and gets it wrong in the
+    // expensive direction - re-asking daily about hopeless descriptions - if a
+    // spent budget makes the cache look empty.
+    it('still knows a refusal it already has after the budget is spent', async () => {
+      await seedCategories();
+      const catalogue = await llmCategorizer.forUser(userId);
+      const request = { description: 'שופרסל דיל', memo: null, categoryTypes: EXPENSE };
+      answering({ category: 'none', confidence: 0.9 });
+
+      expect(await ask(catalogue)).toBeNull();
+      expect(llmCategorizer.hasAnswerFor(catalogue, request)).toBe(true);
+
+      llmService.__setChatError(new AiBudgetExceededError(userId, 200000, 200000));
+      await ask(catalogue, { description: 'something new' });
+      expect(catalogue.budgetExhausted).toBe(true);
+
+      expect(llmCategorizer.hasAnswerFor(catalogue, request)).toBe(true);
+      expect(llmCategorizer.hasAnswerFor(catalogue, { ...request, description: 'never asked' })).toBe(false);
+    });
+
     // A network blip is not a reason to give up on the whole batch, unlike a
     // spent budget.
     it('keeps trying after a one-off failure', async () => {

--- a/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
+++ b/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
@@ -423,6 +423,14 @@ describe('transactionCategorizationService', () => {
         expect(ids.map(String)).toEqual([String(newer._id)]);
       });
 
+      // The off switch. `AI_LLM_RESUME_LIMIT=0` has to survive being read from
+      // the environment, so config uses `numberFromEnv` rather than `||`.
+      it('resumes nothing at all when the limit is zero', async () => {
+        await owed();
+
+        expect(await transactionCategorizationService.outstanding(user._id, 0)).toEqual([]);
+      });
+
       // Catching up is not what the user is waiting for; the scrape that saved
       // their transactions has already done that part.
       it('does not fail a scrape when the backlog cannot be read', async () => {

--- a/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
+++ b/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
@@ -8,6 +8,7 @@ const sseService = require('../../../shared/services/sseService');
 const { Transaction, Category, SubCategory } = require('../../models');
 const { User } = require('../../../auth');
 const llmService = require('../../../shared/services/ai/llmService');
+const { AiBudgetExceededError } = require('../../../shared/services/ai/aiBudget');
 const config = require('../../../shared/config');
 const { createTestUser } = require('../../../test/testUtils');
 const { TransactionStatus, TransactionType, CategorizationMethod } = require('../../constants/enums');
@@ -366,6 +367,108 @@ describe('transactionCategorizationService', () => {
       );
 
       expect(job.updateProgress).toHaveBeenCalledWith(100);
+    });
+  });
+
+  // The queue is fed only by newly-saved transactions, so without this a
+  // transaction the budget cut off before the model ever saw it stays
+  // uncategorised for good and the daily ceiling becomes a cliff.
+  describe('resuming what the budget cut off', () => {
+    const owed = async (description = 'Some Shop', overrides = {}) => {
+      const transaction = await makeTransaction(description);
+      transaction.awaitingModelCategorization = true;
+      Object.assign(transaction, overrides);
+      await transaction.save();
+      return transaction;
+    };
+
+    describe('outstanding', () => {
+      it('returns the transactions the model never saw', async () => {
+        const waiting = await owed();
+        await makeTransaction('never deferred');
+
+        const ids = await transactionCategorizationService.outstanding(user._id);
+
+        expect(ids.map(String)).toEqual([String(waiting._id)]);
+      });
+
+      // Paying the model to have an opinion about a transaction the user has
+      // already filed themselves is pure waste.
+      it('leaves out one the user has categorised in the meantime', async () => {
+        await owed('Some Shop', { category: category._id });
+
+        expect(await transactionCategorizationService.outstanding(user._id)).toEqual([]);
+      });
+
+      it('does not hand one user another user\'s backlog', async () => {
+        await owed();
+        const other = await createTestUser(User, { email: `other${Date.now()}@example.com` });
+
+        expect(await transactionCategorizationService.outstanding(other.user._id)).toEqual([]);
+      });
+
+      // Enqueuing more than a day's allowance can pay for just runs into the
+      // same spent budget and marks them outstanding all over again, so the
+      // backlog is taken newest first rather than all at once.
+      it('takes the newest first, up to the limit', async () => {
+        const older = await owed('older');
+        older.date = new Date('2024-01-01');
+        await older.save();
+        const newer = await owed('newer');
+        newer.date = new Date('2024-06-01');
+        await newer.save();
+
+        const ids = await transactionCategorizationService.outstanding(user._id, 1);
+
+        expect(ids.map(String)).toEqual([String(newer._id)]);
+      });
+
+      // Catching up is not what the user is waiting for; the scrape that saved
+      // their transactions has already done that part.
+      it('does not fail a scrape when the backlog cannot be read', async () => {
+        jest.spyOn(Transaction, 'find').mockImplementation(() => {
+          throw new Error('Mongo is down');
+        });
+
+        await expect(transactionCategorizationService.outstanding(user._id)).resolves.toEqual([]);
+      });
+    });
+
+    // The whole point, end to end: a batch that runs out of budget comes back
+    // and finishes on the next run instead of being abandoned.
+    it('categorises on a later run what the budget cut off on an earlier one', async () => {
+      jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
+      await SubCategory.create({ name: 'Groceries', parentCategory: category._id, userId: user._id });
+      const llmDefault = config.ai.llm.categorization;
+      config.ai.llm.categorization = true;
+      llmService.__setEnabled(true);
+
+      try {
+        const transactions = await Promise.all([makeTransaction('שופרסל'), makeTransaction('ארומה')]);
+        const ids = transactions.map((t) => t._id);
+        llmService.__setChatError(new AiBudgetExceededError(user._id, 200000, 200000));
+
+        const first = await transactionCategorizationService.processBatch({ userId: user._id, transactionIds: ids });
+        expect(first).toMatchObject({ categorized: 0, uncategorized: 2 });
+
+        const waiting = await transactionCategorizationService.outstanding(user._id);
+        expect(waiting.map(String).sort()).toEqual(ids.map(String).sort());
+
+        // Next day: the allowance has rolled over.
+        llmService.__setChatResponse({
+          content: JSON.stringify({ category: 'Food', subCategory: 'Groceries', confidence: 0.9 })
+        });
+
+        const second = await transactionCategorizationService.processBatch({ userId: user._id, transactionIds: waiting });
+        expect(second).toMatchObject({ categorized: 2, uncategorized: 0 });
+
+        const saved = await Transaction.find({ _id: { $in: ids } });
+        expect(saved.map((t) => t.categorizationMethod)).toEqual([CategorizationMethod.AI, CategorizationMethod.AI]);
+        // Cleared, so the backlog drains instead of circling.
+        expect(await transactionCategorizationService.outstanding(user._id)).toEqual([]);
+      } finally {
+        config.ai.llm.categorization = llmDefault;
+      }
     });
   });
 });

--- a/backend/src/banking/services/__tests__/transactionService.test.js
+++ b/backend/src/banking/services/__tests__/transactionService.test.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const transactionService = require('../transactionService');
+const transactionCategorizationService = require('../transactionCategorizationService');
 const { User } = require('../../../auth');
 const { Transaction, Category, SubCategory, ManualCategorized } = require('../../models');
 const { createTestUser } = require('../../../test/testUtils');
@@ -213,6 +214,62 @@ describe('TransactionService', () => {
       expect(result.mostRecentTransactionDate).toEqual(completedDate);
       expect(result.skippedPending).toBe(1);
       expect(result.newTransactions).toBe(1);
+    });
+
+    // The queue is fed only by newly-saved transactions, so a backlog the AI
+    // budget cut off on an earlier run would never be looked at again. A scrape
+    // is when the allowance has rolled over and the work is already batched.
+    describe('picking up what an earlier run could not afford', () => {
+      // Spies here replace a service the whole file uses; clearMocks only
+      // clears the calls, so without this they would still be in place for
+      // every test after these.
+      afterEach(() => jest.restoreAllMocks());
+
+      const owed = (description) =>
+        Transaction.create({
+          identifier: `owed-${Math.random()}`,
+          userId: user._id,
+          accountId: mockBankAccount._id,
+          amount: -75,
+          currency: 'ILS',
+          date: new Date('2026-01-15'),
+          type: TransactionType.EXPENSE,
+          description,
+          awaitingModelCategorization: true,
+          rawData: { description, chargedAmount: -75 }
+        });
+
+      it('queues the backlog alongside the new transactions', async () => {
+        const waiting = await owed('Waiting Shop');
+        const enqueue = jest.spyOn(transactionCategorizationService, 'enqueue').mockResolvedValue('job-1');
+
+        await transactionService.processScrapedTransactions(mockScrapedAccounts, mockBankAccount);
+
+        expect(enqueue).toHaveBeenCalledTimes(1);
+        const [, ids] = enqueue.mock.calls[0];
+        expect(ids.map(String)).toContain(String(waiting._id));
+        expect(ids).toHaveLength(3);
+      });
+
+      // A user whose scrape turns up nothing new still has a backlog to work
+      // off, and this is the only thing that ever comes back for it.
+      it('queues the backlog even when the scrape found nothing new', async () => {
+        const waiting = await owed('Waiting Shop');
+        const enqueue = jest.spyOn(transactionCategorizationService, 'enqueue').mockResolvedValue('job-1');
+
+        const result = await transactionService.processScrapedTransactions([{ txns: [] }], mockBankAccount);
+
+        expect(result.newTransactions).toBe(0);
+        expect(enqueue).toHaveBeenCalledWith(user._id, [waiting._id]);
+      });
+
+      it('queues nothing when there is neither new work nor a backlog', async () => {
+        const enqueue = jest.spyOn(transactionCategorizationService, 'enqueue').mockResolvedValue('job-1');
+
+        await transactionService.processScrapedTransactions([{ txns: [] }], mockBankAccount);
+
+        expect(enqueue).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/backend/src/banking/services/categoryMappingService.js
+++ b/backend/src/banking/services/categoryMappingService.js
@@ -61,13 +61,37 @@ class CategoryMappingService {
   }
 
   /**
-   * Nothing placed it, so record what its amount implies and leave it for the user.
+   * Nothing placed it, so record what its amount implies and leave it for the
+   * user - along with whether the model actually looked at it.
+   *
+   * A budget that ran out before this transaction's turn means the model never
+   * saw it, and it should be asked about on a later run. One the model saw and
+   * declined is finished: re-asking would spend the same money on the same
+   * refusal every day, and this tier declines readily by design.
+   *
+   * The flag is cleared as well as set, so a transaction that was owed a look
+   * and has now had one leaves the resume queue instead of circling in it.
    */
-  async applyDefaultType(transaction) {
+  async settleUnanswered(transaction, catalogue) {
+    // A refusal already in this run's cache is an answer, even though it leaves
+    // the transaction looking exactly like one the model never saw. Without
+    // that check, a budget that trips halfway through a scrape would mark every
+    // transaction sharing an already-declined description as unseen.
+    const stillOwed = Boolean(catalogue?.budgetExhausted)
+      && !llmCategorizer.hasAnswerFor(catalogue, this.toModelRequest(transaction));
+    let changed = false;
+
     if (!transaction.type) {
       transaction.type = transaction.amount < 0 ? TransactionType.EXPENSE : TransactionType.INCOME;
-      await transaction.save();
+      changed = true;
     }
+
+    if (Boolean(transaction.awaitingModelCategorization) !== stillOwed) {
+      transaction.awaitingModelCategorization = stillOwed;
+      changed = true;
+    }
+
+    if (changed) await transaction.save();
   }
 
   /**
@@ -108,7 +132,7 @@ class CategoryMappingService {
 
       if (suggestion) return await this.applySuggestion(transaction, suggestion);
 
-      await this.applyDefaultType(transaction);
+      await this.settleUnanswered(transaction, catalogue);
     } catch (error) {
       logger.error('Deferred auto-categorization failed:', error);
     }
@@ -398,7 +422,7 @@ class CategoryMappingService {
         return await this.applySuggestion(transaction, llmSuggestion);
       }
 
-      await this.applyDefaultType(transaction);
+      await this.settleUnanswered(transaction, activeCatalogue);
     } catch (error) {
       logger.error('Auto-categorization failed:', error);
       return undefined;

--- a/backend/src/banking/services/llmCategorizer.js
+++ b/backend/src/banking/services/llmCategorizer.js
@@ -274,6 +274,21 @@ class LlmCategorizer {
   }
 
   /**
+   * Whether this run already holds the model's answer for a request, refusals
+   * included.
+   *
+   * Lets a caller tell "the model looked at this and said no" apart from "the
+   * model never saw this", which is the difference between a transaction worth
+   * coming back to and one that would cost the same money for the same refusal
+   * every day. The two are otherwise indistinguishable, because both leave the
+   * transaction without a category.
+   */
+  hasAnswerFor(catalogue, { description, memo, categoryTypes }) {
+    if (!catalogue) return false;
+    return catalogue.answers.has(cacheKey(categoryTypes, description, memo));
+  }
+
+  /**
    * Suggests a category for one transaction against an already-loaded catalogue.
    *
    * Returns null rather than a low-confidence guess, on the same reasoning as
@@ -282,7 +297,6 @@ class LlmCategorizer {
    */
   async suggestFrom(catalogue, { description, memo, amount, categoryTypes }) {
     if (!catalogue || !this.isEnabled()) return null;
-    if (catalogue.budgetExhausted) return null;
 
     const text = [description, memo].filter(Boolean).join(' ').trim();
     if (!text) return null;
@@ -295,6 +309,12 @@ class LlmCategorizer {
     if (catalogue.answers.has(key)) {
       return catalogue.answers.get(key);
     }
+
+    // Deliberately checked after the cache rather than before it. An answer this
+    // run has already paid for costs nothing to reuse, and discarding it would
+    // make a transaction the model has already judged look like one it never
+    // saw - which is the single thing the caller uses this null to decide.
+    if (catalogue.budgetExhausted) return null;
 
     const choices = this.describeChoices(catalogue, categoryTypes);
     if (choices.length === 0) return null;

--- a/backend/src/banking/services/transactionCategorizationService.js
+++ b/backend/src/banking/services/transactionCategorizationService.js
@@ -4,6 +4,7 @@ const transactionClassifier = require('./transactionClassifier');
 const llmCategorizer = require('./llmCategorizer');
 const scrapingQueue = require('../../shared/services/scrapingQueue');
 const sseService = require('../../shared/services/sseService');
+const config = require('../../shared/config');
 const logger = require('../../shared/utils/logger');
 
 const JOB_TYPE = 'categorize-transactions';
@@ -42,6 +43,44 @@ class TransactionCategorizationService {
       // sync failed when it did not.
       logger.error(`Could not queue categorization for user ${userId}: ${error.message}`);
       return null;
+    }
+  }
+
+  /**
+   * The transactions the model never saw because the budget ran out on an
+   * earlier run, newest first.
+   *
+   * This is what keeps a budget ceiling from being a cliff. Nothing else ever
+   * revisits an uncategorised transaction - the queue is fed only by
+   * newly-saved ones - so without this, everything past the day's allowance
+   * stays uncategorised for good.
+   *
+   * `category: null` is checked as well as the flag because the user may have
+   * categorised it themselves in the meantime, and paying the model to have an
+   * opinion about a transaction they have already filed is pure waste.
+   */
+  async outstanding(userId, limit = config.ai.llm.resumeLimit) {
+    if (!limit || limit <= 0) return [];
+
+    try {
+      const rows = await Transaction.find({
+        userId,
+        awaitingModelCategorization: true,
+        category: null
+      })
+        .select('_id')
+        .sort({ date: -1 })
+        .limit(limit)
+        .lean();
+
+      return rows.map((row) => row._id);
+    } catch (error) {
+      // Resuming is catch-up work. A scrape that saved its transactions has
+      // done the part the user is waiting for, and failing it because the
+      // backlog could not be read would be a worse outcome than trying again
+      // on the next scrape.
+      logger.error(`Could not read outstanding categorization for user ${userId}: ${error.message}`);
+      return [];
     }
   }
 

--- a/backend/src/banking/services/transactionService.js
+++ b/backend/src/banking/services/transactionService.js
@@ -232,10 +232,20 @@ class TransactionService {
 
     // Queued after the loop rather than per transaction, so the batch shares one
     // load of the user's past corrections.
-    if (pendingCategorization.length) {
+    //
+    // A scrape is also the natural moment to come back to whatever the model
+    // never got to last time: the user's budget has rolled over, and the work
+    // is already batched. Without this a first import would be capped for ever
+    // at one day's allowance rather than finishing over a few days.
+    const resuming = await transactionCategorizationService.outstanding(bankAccount.userId);
+    if (resuming.length) {
+      console.log(`Resuming categorization for ${resuming.length} transaction(s) the model has not seen`);
+    }
+
+    if (pendingCategorization.length || resuming.length) {
       results.categorizationJobId = await transactionCategorizationService.enqueue(
         bankAccount.userId,
-        pendingCategorization
+        [...pendingCategorization, ...resuming]
       );
     }
 

--- a/backend/src/shared/config/index.js
+++ b/backend/src/shared/config/index.js
@@ -121,7 +121,17 @@ const config = {
       // transaction in a group, so asking about ten at once sends it once
       // instead of ten times. Measured at ~730 input tokens per single call
       // against ~940 for a batch of ten. Set to 1 to go back to one call each.
-      batchSize: Number(process.env.AI_LLM_BATCH_SIZE) || 10
+      batchSize: Number(process.env.AI_LLM_BATCH_SIZE) || 10,
+      // How many transactions the model never got to are pulled back in per
+      // scrape, newest first.
+      //
+      // Sized against what a day's token budget can pay for rather than against
+      // the backlog: anything enqueued beyond that allowance simply runs into
+      // the same spent budget and is marked outstanding again, so a larger
+      // number adds queue traffic without categorising anything more. A large
+      // first import therefore converges over several days instead of in one
+      // go, which is the intended trade.
+      resumeLimit: Number(process.env.AI_LLM_RESUME_LIMIT) || 1000
     }
   }
 };

--- a/backend/src/shared/config/index.js
+++ b/backend/src/shared/config/index.js
@@ -131,7 +131,9 @@ const config = {
       // number adds queue traffic without categorising anything more. A large
       // first import therefore converges over several days instead of in one
       // go, which is the intended trade.
-      resumeLimit: Number(process.env.AI_LLM_RESUME_LIMIT) || 1000
+      //
+      // 0 is meaningful here - it is the off switch, honoured by `outstanding`.
+      resumeLimit: numberFromEnv(process.env.AI_LLM_RESUME_LIMIT, 1000)
     }
   }
 };

--- a/backend/src/test/mocks/llmService.js
+++ b/backend/src/test/mocks/llmService.js
@@ -38,6 +38,31 @@ const fakeEmbedding = (text) => {
 // need "near" and "far" to mean something register their own vectors here.
 const overrides = new Map();
 
+const defaultChat = async ({ userId }) => {
+  if (!enabled) throw new AiNotConfiguredError();
+  if (!userId) throw new Error('llmService.chat requires a userId to charge the request to');
+  if (chatError) throw chatError;
+  return {
+    content: chatResponse.content,
+    finishReason: chatResponse.finishReason || 'stop',
+    model: 'mock-chat',
+    usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 }
+  };
+};
+
+const defaultEmbed = async ({ userId, texts }) => {
+  if (!enabled) throw new AiNotConfiguredError();
+  if (!userId) throw new Error('llmService.embed requires a userId to charge the request to');
+  const input = Array.isArray(texts) ? texts : [texts];
+  const vectors = input.map(fakeEmbedding);
+  return {
+    vectors,
+    dimensions: vectors.length ? MOCK_DIMENSIONS : 0,
+    model: 'mock-embedding',
+    usage: { totalTokens: input.length }
+  };
+};
+
 module.exports = {
   isEnabled: jest.fn(() => enabled),
 
@@ -47,30 +72,9 @@ module.exports = {
     if (!enabled) throw new AiNotConfiguredError();
   }),
 
-  chat: jest.fn(async ({ userId }) => {
-    if (!enabled) throw new AiNotConfiguredError();
-    if (!userId) throw new Error('llmService.chat requires a userId to charge the request to');
-    if (chatError) throw chatError;
-    return {
-      content: chatResponse.content,
-      finishReason: chatResponse.finishReason || 'stop',
-      model: 'mock-chat',
-      usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 }
-    };
-  }),
+  chat: jest.fn(defaultChat),
 
-  embed: jest.fn(async ({ userId, texts }) => {
-    if (!enabled) throw new AiNotConfiguredError();
-    if (!userId) throw new Error('llmService.embed requires a userId to charge the request to');
-    const input = Array.isArray(texts) ? texts : [texts];
-    const vectors = input.map(fakeEmbedding);
-    return {
-      vectors,
-      dimensions: vectors.length ? MOCK_DIMENSIONS : 0,
-      model: 'mock-embedding',
-      usage: { totalTokens: input.length }
-    };
-  }),
+  embed: jest.fn(defaultEmbed),
 
   asUntrustedData: jest.fn((text, label = 'data') =>
     `<untrusted source="${label}">\n${String(text ?? '').replace(/<\/?untrusted[^>]*>/gi, '').trim()}\n</untrusted>`
@@ -89,5 +93,12 @@ module.exports = {
     chatResponse = { content: '', finishReason: 'stop' };
     chatError = null;
     overrides.clear();
+    // A test that swaps in its own implementation - to drive a race from inside
+    // the request, say - is otherwise still swapped in for every test after it,
+    // because clearMocks only clears the calls. That silently makes
+    // __setChatResponse and __setChatError do nothing, which looks like a bug in
+    // whatever runs next rather than in the test that caused it.
+    module.exports.chat.mockImplementation(defaultChat);
+    module.exports.embed.mockImplementation(defaultEmbed);
   }
 };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,6 +161,25 @@ per-user daily token budget stops a runaway loop, and the first
 `AiBudgetExceededError` switches the tier off for the rest of the batch instead
 of paying for the same refusal hundreds of times.
 
+Switching the tier off mid-batch would be a cliff rather than a ceiling if
+nothing came back for what it skipped: the categorisation queue is fed only by
+newly-saved transactions, so an uncategorised one is never revisited. A
+transaction the budget cut off is therefore marked
+`awaitingModelCategorization`, and the next scrape pulls up to
+`AI_LLM_RESUME_LIMIT` of them back into the same batched job, newest first. A
+first import that outruns a day's allowance finishes over the following days
+instead of leaving the remainder uncategorised for good.
+
+The mark is deliberately narrow. It is set only when the model never saw the
+transaction, never when it saw it and declined — the tier declines readily by
+design, and re-asking about every unrecognisable description would spend the
+whole allowance on the same refusals every day. That includes a refusal already
+sitting in the run's answer cache, which is why `llmCategorizer.suggestFrom`
+reads the cache before checking the budget and why `hasAnswerFor` exists: after
+the budget trips, an answer already paid for is still an answer. Anything that
+gains a category — from the user, a cheap tier or the model — is unmarked by
+`Transaction.categorize`, so nothing can circle in the backlog.
+
 The model is never allowed to invent a category. It is shown only the user's own
 categories whose type matches the transaction's sign, and its answer is resolved
 back against them by name — so a hallucinated category, or one talked into it by


### PR DESCRIPTION
## The problem

The per-user daily token budget was a **cliff, not a ceiling**.

`aiBudget.assertWithinBudget()` throws once a user has spent their allowance;
`llmCategorizer.handleRequestError()` catches it and switches the model tier off
for the rest of the run. That degradation is deliberate and correct — the cheap
tiers still run, and the scrape still finishes.

What was missing is that **nothing ever came back**:

- `transactionCategorizationService.enqueue()` has exactly one caller
  (`transactionService.js`), fed only by **newly saved** transactions.
- No cron re-categorises. The scrape, price, currency and snapshot jobs all do
  something else.

So every transaction past the day's allowance was abandoned permanently. Raising
`AI_DAILY_TOKEN_BUDGET` from 200k to 2M would only have moved the cliff.

## Why the obvious fix is worse than the bug

A "retry everything uncategorised" sweep would re-ask the model, every day, about
every transaction it had **deliberately declined** — and tier 4 declines readily
by design. That burns the entire allowance on hopeless descriptions, for ever.

The data model couldn't tell the two apart: `categorizationMethod` and
`categorizationReasoning` are only written on success, so "model declined" and
"model never saw it" both look like `category: null`.

## What this does

- **`Transaction.awaitingModelCategorization`** records that the model still owes
  this transaction a look. Partial index, so it holds the outstanding few rather
  than a boolean for every transaction ever, and empties as the backlog drains.
- **`categoryMappingService.settleUnanswered`** (was `applyDefaultType`) sets it
  only when the budget cut the model off, and **clears** it once the model has
  looked — even if it declined.
- **`transactionCategorizationService.outstanding()`** returns the backlog,
  newest first, capped at `AI_LLM_RESUME_LIMIT` (default 1000), skipping anything
  the user has since categorised themselves.
- **`transactionService`** includes it in the single `enqueue` call it already
  makes, so a first import converges over successive scrapes with no new cron.
- **`Transaction.categorize`** clears the mark, so nothing that gains a category —
  from the user, a cheap tier or the model — can circle in the backlog.

### The subtle one

A refusal already in the run's answer cache **is** an answer. `suggestFrom` now
reads the cache **before** checking the budget, and `llmCategorizer.hasAnswerFor`
lets the settling path tell "declined" from "never reached" for a transaction
whose merchant was already asked about.

Without it, a budget tripping halfway through a scrape marks every transaction
sharing an already-declined description as unseen — exactly the daily re-asking
this change exists to prevent. I found this by mutation-testing the first draft,
wrote the failing test, then fixed it.

### Not done on purpose

Existing uncategorised transactions are left alone. There is no way to tell which
the model declined and which it never reached, and guessing wrong costs real
money. Not an issue in practice — the big first import hasn't happened yet.

## Drive-by: a test-isolation bug this exposed

`src/test/mocks/llmService.js` is shared by every suite, and `clearMocks: true`
clears calls but **not** implementations. One test swaps in its own `chat`
implementation to drive a race from inside the request — and that implementation
stayed in place for every test after it, silently making `__setChatResponse` and
`__setChatError` do nothing.

My integration test failed only in a full-file run, passed alone. `__reset` now
restores the default implementations, which is what the comment at the reset site
already claimed it did.

## Verification

- `npx jest` (backend): **55 suites, 1075 passing**, 6 pre-existing skips.
- **14 mutations, 14 killed.** Every new assertion is load-bearing — including
  the mock fix (reverting it breaks the integration test) and the cache-ordering
  change.
- One test in the first draft passed under its own mutation, so it was replaced
  with one that can actually fail.

## Follow-up

`AI_LLM_RESUME_LIMIT` is sized against an **inferred** ~124 tokens/transaction.
`llmService` logs tokens per call but nothing aggregates them per run, so the
next step is to measure a real import and set both it and
`AI_DAILY_TOKEN_BUDGET` from real numbers.

Note: OTP-only accounts are excluded from *scheduled* scraping, so those users
resume when they scrape manually — both sync strategies go through
`processScrapedTransactions`.
