### PR TITLE
Measure what a categorisation run actually costs

### DIFF
--- a/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
+++ b/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
@@ -6,10 +6,12 @@ const llmCategorizer = require('../llmCategorizer');
 const scrapingQueue = require('../../../shared/services/scrapingQueue');
 const sseService = require('../../../shared/services/sseService');
 const { Transaction, Category, SubCategory } = require('../../models');
+const ManualCategorized = require('../../models/ManualCategorized');
 const { User } = require('../../../auth');
 const llmService = require('../../../shared/services/ai/llmService');
 const { AiBudgetExceededError } = require('../../../shared/services/ai/aiBudget');
 const config = require('../../../shared/config');
+const logger = require('../../../shared/utils/logger');
 const { createTestUser } = require('../../../test/testUtils');
 const { TransactionStatus, TransactionType, CategorizationMethod } = require('../../constants/enums');
 
@@ -367,6 +369,136 @@ describe('transactionCategorizationService', () => {
       );
 
       expect(job.updateProgress).toHaveBeenCalledWith(100);
+    });
+
+    // The daily ceiling has to be picked from a real number, and until now the
+    // only evidence was per-call log lines that nobody added up over a run.
+    describe('what the run cost', () => {
+      const llmDefault = config.ai.llm.categorization;
+      const deploymentDefault = config.ai.embeddingDeployment;
+      let subCategory;
+
+      beforeEach(async () => {
+        config.ai.llm.categorization = true;
+        // Embedding is off by default in the suite, and with it off the kNN tier
+        // never calls out - so a run would spend only on chat and this would
+        // test half of what it claims to.
+        config.ai.embeddingDeployment = 'text-embedding-3-small';
+        llmService.__setEnabled(true);
+        jest.spyOn(sseService, 'emit').mockImplementation(() => {});
+        subCategory = await SubCategory.create({
+          name: 'Groceries', parentCategory: category._id, userId: user._id
+        });
+      });
+
+      afterEach(() => {
+        config.ai.llm.categorization = llmDefault;
+        config.ai.embeddingDeployment = deploymentDefault;
+      });
+
+      const answeringBatch = (count) => llmService.__setChatResponse({
+        content: JSON.stringify({
+          answers: Array.from({ length: count }, (_, index) => ({
+            id: index + 1, category: 'Food', subCategory: 'Groceries', confidence: 0.9
+          }))
+        })
+      });
+
+      const costLine = (info) => {
+        const call = info.mock.calls.find(([message]) => String(message).startsWith('Categorization cost'));
+        return call && call[0];
+      };
+
+      // Three different services spend on one run - the classifier embedding the
+      // corpus, the classifier embedding each query, the categoriser asking the
+      // model - and the total is only worth having if it covers all of them.
+      // That is the reason the meter follows the async context rather than being
+      // an argument each of them has to remember to pass on.
+      it('adds up every service that spent, not just the one that logs', async () => {
+        // Hand-picked so the corpus sits far from both transactions: a chance
+        // kNN match would place them, the model would never be asked, and this
+        // would quietly become a test of something else.
+        llmService.__setEmbedding('שופרסל דיל', [1, 0, 0, 0]);
+        llmService.__setEmbedding('ארומה', [0, 1, 0, 0]);
+        llmService.__setEmbedding('דלק', [0, 0, 1, 0]);
+        await ManualCategorized.create({
+          description: 'שופרסל דיל',
+          userId: user._id,
+          category: category._id,
+          subCategory: subCategory._id
+        });
+        answeringBatch(2);
+        const transactions = await Promise.all([makeTransaction('ארומה'), makeTransaction('דלק')]);
+        const info = jest.spyOn(logger, 'info');
+
+        await transactionCategorizationService.processBatch({
+          userId: user._id,
+          transactionIds: transactions.map((t) => t._id)
+        });
+
+        // One corpus embed and two query embeds, a token each in the mock, plus
+        // one batched chat covering both transactions.
+        expect(costLine(info)).toContain('tokens=23 calls=4');
+        expect(costLine(info)).toContain('categorisation-fallback-batch=20 in 1 call');
+        expect(costLine(info)).toContain('categorisation-corpus=1 in 1 call');
+        expect(costLine(info)).toContain('categorisation-query=2 in 2 calls');
+      });
+
+      // The figure the budget is chosen from, stated outright rather than left
+      // to be worked out from two other numbers on the line.
+      it('states the per-transaction cost the budget has to be sized against', async () => {
+        jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
+        answeringBatch(2);
+        const transactions = await Promise.all([makeTransaction('ארומה'), makeTransaction('דלק')]);
+        const info = jest.spyOn(logger, 'info');
+
+        await transactionCategorizationService.processBatch({
+          userId: user._id,
+          transactionIds: transactions.map((t) => t._id)
+        });
+
+        expect(costLine(info)).toContain('transactions=2');
+        expect(costLine(info)).toContain('tokens=20');
+        expect(costLine(info)).toContain('perTransaction=10.0');
+      });
+
+      // With AI off - which is every environment that has not configured it -
+      // this would otherwise be a line per batch reporting that nothing happened.
+      it('says nothing at all when the run spent nothing', async () => {
+        llmService.__setEnabled(false);
+        jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
+        const transaction = await makeTransaction();
+        const info = jest.spyOn(logger, 'info');
+
+        await transactionCategorizationService.processBatch({
+          userId: user._id,
+          transactionIds: [transaction._id]
+        });
+
+        expect(costLine(info)).toBeUndefined();
+      });
+
+      // Loading the corpus spends before any transaction is looked at, so the
+      // division genuinely can have a zero in it - and a stray Infinity would
+      // discredit the one line this whole change exists to produce.
+      it('does not divide by an empty batch', async () => {
+        await ManualCategorized.create({
+          description: 'שופרסל דיל',
+          userId: user._id,
+          category: category._id,
+          subCategory: subCategory._id
+        });
+        const info = jest.spyOn(logger, 'info');
+
+        await transactionCategorizationService.processBatch({
+          userId: user._id,
+          transactionIds: []
+        });
+
+        expect(costLine(info)).toContain('transactions=0');
+        expect(costLine(info)).not.toContain('Infinity');
+        expect(costLine(info)).not.toContain('NaN');
+      });
     });
   });
 

--- a/backend/src/banking/services/transactionCategorizationService.js
+++ b/backend/src/banking/services/transactionCategorizationService.js
@@ -4,6 +4,7 @@ const transactionClassifier = require('./transactionClassifier');
 const llmCategorizer = require('./llmCategorizer');
 const scrapingQueue = require('../../shared/services/scrapingQueue');
 const sseService = require('../../shared/services/sseService');
+const aiCostMeter = require('../../shared/services/ai/aiCostMeter');
 const config = require('../../shared/config');
 const logger = require('../../shared/utils/logger');
 
@@ -85,9 +86,39 @@ class TransactionCategorizationService {
   }
 
   /**
-   * Categorises a batch, reporting progress as it goes.
+   * Categorises a batch, reporting progress as it goes, and reports what the
+   * batch cost.
+   *
+   * The cost is the reason for the split: the per-transaction token figure the
+   * daily budget is sized against was never anything but an estimate, because
+   * every call logged its own tokens and nothing added them up over a run.
    */
   async processBatch({ userId, transactionIds }, job) {
+    const { result, cost } = await aiCostMeter.measure(
+      () => this.runBatch({ userId, transactionIds }, job)
+    );
+
+    // Only when something was actually spent. With AI switched off every batch
+    // would otherwise log a line saying nothing was spent, and this line exists
+    // to be found in the logs of the one import worth measuring.
+    if (cost.calls > 0) {
+      // Loading the corpus costs tokens before any transaction is looked at, so
+      // an empty batch can still spend - and dividing by it would print the
+      // Infinity that makes the whole line untrustworthy.
+      const perTransaction = transactionIds.length
+        ? ` perTransaction=${(cost.tokens / transactionIds.length).toFixed(1)}`
+        : '';
+      logger.info(
+        `Categorization cost user=${userId} transactions=${transactionIds.length} ` +
+        `tokens=${cost.tokens} calls=${cost.calls}${perTransaction} ` +
+        `(${cost.breakdown})`
+      );
+    }
+
+    return result;
+  }
+
+  async runBatch({ userId, transactionIds }, job) {
     const corpus = await transactionClassifier.forUser(userId);
     const catalogue = await llmCategorizer.forUser(userId);
     // Clients are keyed by the string form of the id, and the job payload may

--- a/backend/src/shared/services/ai/__tests__/aiCostMeter.test.js
+++ b/backend/src/shared/services/ai/__tests__/aiCostMeter.test.js
@@ -1,0 +1,101 @@
+const aiCostMeter = require('../aiCostMeter');
+
+// The number this produces is what the daily token budget gets sized against,
+// so the ways it could be quietly wrong - counting another run's tokens,
+// losing a nested step's - are pinned here rather than discovered by setting a
+// ceiling from a figure nobody checked.
+describe('aiCostMeter', () => {
+  it('adds up what was spent inside the work it measures', async () => {
+    const { result, cost } = await aiCostMeter.measure(async () => {
+      aiCostMeter.record('categorisation-query', 12);
+      aiCostMeter.record('categorisation-fallback-batch', 300);
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(cost.tokens).toBe(312);
+    expect(cost.calls).toBe(2);
+  });
+
+  it('keeps the purposes apart, so a run shows what the money went on', async () => {
+    const { cost } = await aiCostMeter.measure(async () => {
+      aiCostMeter.record('categorisation-query', 10);
+      aiCostMeter.record('categorisation-query', 14);
+      aiCostMeter.record('categorisation-fallback-batch', 300);
+    });
+
+    expect(cost.byPurpose).toEqual({
+      'categorisation-query': { tokens: 24, calls: 2 },
+      'categorisation-fallback-batch': { tokens: 300, calls: 1 }
+    });
+    // Dearest first: the point of reading this line is to find what to cut.
+    expect(cost.breakdown).toBe(
+      'categorisation-fallback-batch=300 in 1 call, categorisation-query=24 in 2 calls'
+    );
+  });
+
+  // The low-priority queue runs two jobs at once and the request-driven AI paths
+  // share the process. Measuring as a delta on the shared per-user counter would
+  // charge each of these for the other's tokens.
+  it('does not let overlapping runs charge each other', async () => {
+    const started = [];
+    const spend = async (purpose, tokens, delay) => aiCostMeter.measure(async () => {
+      started.push(purpose);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      aiCostMeter.record(purpose, tokens);
+    });
+
+    const [first, second] = await Promise.all([
+      spend('slow', 500, 20),
+      spend('fast', 7, 1)
+    ]);
+
+    // Interleaved, not one after the other - otherwise this proves nothing.
+    expect(started).toEqual(['slow', 'fast']);
+    expect(first.cost.tokens).toBe(500);
+    expect(second.cost.tokens).toBe(7);
+  });
+
+  it('counts a nested step against the run that contains it', async () => {
+    const { cost, result } = await aiCostMeter.measure(async () => {
+      aiCostMeter.record('outer', 5);
+      const inner = await aiCostMeter.measure(async () => {
+        aiCostMeter.record('inner', 100);
+      });
+      return inner.cost;
+    });
+
+    expect(result.tokens).toBe(100);
+    expect(cost.tokens).toBe(105);
+  });
+
+  it('counts a request that returned nothing, because it was still a request', async () => {
+    const { cost } = await aiCostMeter.measure(async () => {
+      aiCostMeter.record('categorisation-query', 0);
+    });
+
+    expect(cost).toMatchObject({ tokens: 0, calls: 1 });
+  });
+
+  it('ignores a total that is not a number rather than poisoning the run', async () => {
+    const { cost } = await aiCostMeter.measure(async () => {
+      aiCostMeter.record('categorisation-query', undefined);
+      aiCostMeter.record('categorisation-query', -5);
+      aiCostMeter.record('categorisation-query', 8);
+    });
+
+    expect(cost).toMatchObject({ tokens: 8, calls: 1 });
+  });
+
+  // Most calls are one-off - a chat turn, an onboarding question - and nobody is
+  // measuring those. Recording has to be safe outside a run.
+  it('is a no-op outside any measurement', () => {
+    expect(() => aiCostMeter.record('categorisation-query', 10)).not.toThrow();
+  });
+
+  it('gives back what the measured work returned, and lets it throw', async () => {
+    await expect(
+      aiCostMeter.measure(async () => { throw new Error('categorisation blew up'); })
+    ).rejects.toThrow('categorisation blew up');
+  });
+});

--- a/backend/src/shared/services/ai/__tests__/llmService.test.js
+++ b/backend/src/shared/services/ai/__tests__/llmService.test.js
@@ -1,4 +1,5 @@
 const config = require('../../../config');
+const aiCostMeter = require('../aiCostMeter');
 
 // The suite mocks this module globally so nothing can reach the network by
 // accident. These tests are about the real implementation's guard rails, so they
@@ -75,6 +76,61 @@ describe('llmService', () => {
         model: 'text-embedding-3-small',
         usage: { totalTokens: 0 }
       });
+    });
+  });
+
+  // What a run costs is only knowable if every completed request reports itself.
+  // This is the one place that talks to the model, so a request that skipped it
+  // would be spend that no measurement could ever see - and the daily budget is
+  // sized from those measurements.
+  describe('metering', () => {
+    beforeEach(enable);
+
+    const clientReturning = (response) => jest.spyOn(llmService, 'getClient').mockReturnValue({
+      chat: { completions: { create: jest.fn().mockResolvedValue(response) } },
+      embeddings: { create: jest.fn().mockResolvedValue(response) }
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('reports what a chat request spent', async () => {
+      clientReturning({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 700, completion_tokens: 30, total_tokens: 730 }
+      });
+
+      const { cost } = await aiCostMeter.measure(
+        () => llmService.chat({ userId: 'u1', messages: [], purpose: 'categorisation-fallback' })
+      );
+
+      expect(cost.byPurpose).toEqual({ 'categorisation-fallback': { tokens: 730, calls: 1 } });
+    });
+
+    it('reports what an embedding request spent', async () => {
+      clientReturning({
+        data: [{ index: 0, embedding: [0, 1] }],
+        usage: { total_tokens: 9 }
+      });
+
+      const { cost } = await aiCostMeter.measure(
+        () => llmService.embed({ userId: 'u1', texts: ['שופרסל'], purpose: 'categorisation-query' })
+      );
+
+      expect(cost.byPurpose).toEqual({ 'categorisation-query': { tokens: 9, calls: 1 } });
+    });
+
+    // A failed request bought nothing and reports no usage, so counting it would
+    // inflate the very figure the budget is chosen from.
+    it('reports nothing for a request that failed', async () => {
+      jest.spyOn(llmService, 'getClient').mockReturnValue({
+        chat: { completions: { create: jest.fn().mockRejectedValue(new Error('429')) } }
+      });
+
+      const { cost } = await aiCostMeter.measure(async () => {
+        await llmService.chat({ userId: 'u1', messages: [] }).catch(() => {});
+      });
+
+      expect(cost).toMatchObject({ tokens: 0, calls: 0 });
     });
   });
 

--- a/backend/src/shared/services/ai/aiCostMeter.js
+++ b/backend/src/shared/services/ai/aiCostMeter.js
@@ -1,0 +1,85 @@
+const { AsyncLocalStorage } = require('async_hooks');
+
+/**
+ * Adds up what one piece of work spent with the model.
+ *
+ * `aiBudget` answers "has this user spent too much today". This answers the
+ * question the budget has to be *chosen* from - "what did one run actually
+ * cost" - which nothing could report before: every call logged its own tokens
+ * and nothing added them up, so the per-transaction figure the ceiling is sized
+ * against was an estimate that no run had ever confirmed.
+ *
+ * Scoped to the async context rather than read as a before/after delta on the
+ * shared per-user counter, because runs overlap. The low-priority queue runs two
+ * jobs at once and the request-driven AI paths share the process, so a delta
+ * would quietly charge one run for another's tokens - worst of all during a
+ * large import, which is exactly when the measurement matters.
+ */
+const storage = new AsyncLocalStorage();
+
+const describe = (byPurpose) =>
+  [...byPurpose.entries()]
+    .sort((a, b) => b[1].tokens - a[1].tokens)
+    .map(([purpose, { tokens, calls }]) => `${purpose}=${tokens} in ${calls} call${calls === 1 ? '' : 's'}`)
+    .join(', ');
+
+const summarise = (meter) => ({
+  tokens: meter.tokens,
+  calls: meter.calls,
+  byPurpose: Object.fromEntries(
+    [...meter.byPurpose.entries()].map(([purpose, totals]) => [purpose, { ...totals }])
+  ),
+  breakdown: describe(meter.byPurpose)
+});
+
+class AiCostMeter {
+  /**
+   * Runs `fn`, returning both its result and what it spent.
+   *
+   * Everything the model is asked for inside counts, however deep - the point is
+   * the total a run costs, and threading an accumulator through the classifier,
+   * the categoriser and the batching would only measure the places someone
+   * remembered to thread it through.
+   */
+  async measure(fn) {
+    const meter = {
+      parent: storage.getStore(),
+      tokens: 0,
+      calls: 0,
+      byPurpose: new Map()
+    };
+
+    const result = await storage.run(meter, fn);
+    return { result, cost: summarise(meter) };
+  }
+
+  /**
+   * Notes one completed request. Called from `llmService`, so a caller cannot
+   * spend anything without it being counted.
+   *
+   * Deliberately total: a measurement is worth less than the result it is
+   * measuring, so nothing here is allowed to fail the request. Outside any
+   * `measure` it is a no-op, which is the normal case for a one-off request.
+   */
+  record(purpose, tokens) {
+    const amount = Number(tokens);
+    // 0 still counts as a call - a request that returned nothing useful is a
+    // request that was made, and a run full of them is worth seeing.
+    if (!Number.isFinite(amount) || amount < 0) return;
+
+    const key = purpose || 'unspecified';
+
+    // Up the whole chain, so measuring an inner step does not hide its cost from
+    // an outer measurement of the run that contains it.
+    for (let meter = storage.getStore(); meter; meter = meter.parent) {
+      meter.tokens += amount;
+      meter.calls += 1;
+      const totals = meter.byPurpose.get(key) || { tokens: 0, calls: 0 };
+      totals.tokens += amount;
+      totals.calls += 1;
+      meter.byPurpose.set(key, totals);
+    }
+  }
+}
+
+module.exports = new AiCostMeter();

--- a/backend/src/shared/services/ai/index.js
+++ b/backend/src/shared/services/ai/index.js
@@ -1,9 +1,11 @@
 const llmService = require('./llmService');
 const aiBudget = require('./aiBudget');
+const aiCostMeter = require('./aiCostMeter');
 
 module.exports = {
   llmService,
   aiBudget,
+  aiCostMeter,
   AiNotConfiguredError: llmService.AiNotConfiguredError,
   AiBudgetExceededError: aiBudget.AiBudgetExceededError
 };

--- a/backend/src/shared/services/ai/llmService.js
+++ b/backend/src/shared/services/ai/llmService.js
@@ -3,6 +3,7 @@ const { DefaultAzureCredential, getBearerTokenProvider } = require('@azure/ident
 const logger = require('../../utils/logger');
 const config = require('../../config');
 const aiBudget = require('./aiBudget');
+const aiCostMeter = require('./aiCostMeter');
 
 const COGNITIVE_SERVICES_SCOPE = 'https://cognitiveservices.azure.com/.default';
 
@@ -163,6 +164,7 @@ class LlmService {
 
     const usage = response.usage || {};
     await aiBudget.record(userId, usage.total_tokens || 0);
+    aiCostMeter.record(purpose, usage.total_tokens || 0);
 
     logger.info(
       `LLM chat purpose=${purpose} tokens=${usage.total_tokens || 0} ms=${Date.now() - startedAt}`
@@ -214,6 +216,7 @@ class LlmService {
 
     const usage = response.usage || {};
     await aiBudget.record(userId, usage.total_tokens || 0);
+    aiCostMeter.record(purpose, usage.total_tokens || 0);
 
     // The API does not promise ordering, but it does return an index per item.
     const vectors = [...response.data]

--- a/backend/src/test/mocks/llmService.js
+++ b/backend/src/test/mocks/llmService.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const aiCostMeter = require('../../shared/services/ai/aiCostMeter');
 
 class AiNotConfiguredError extends Error {
   constructor() {
@@ -38,23 +39,28 @@ const fakeEmbedding = (text) => {
 // need "near" and "far" to mean something register their own vectors here.
 const overrides = new Map();
 
-const defaultChat = async ({ userId }) => {
+const defaultChat = async ({ userId, purpose }) => {
   if (!enabled) throw new AiNotConfiguredError();
   if (!userId) throw new Error('llmService.chat requires a userId to charge the request to');
   if (chatError) throw chatError;
+  const usage = { promptTokens: 10, completionTokens: 10, totalTokens: 20 };
+  // The real service meters every call it completes, so a mock that did not
+  // would let a run report a cost of zero and pass.
+  aiCostMeter.record(purpose, usage.totalTokens);
   return {
     content: chatResponse.content,
     finishReason: chatResponse.finishReason || 'stop',
     model: 'mock-chat',
-    usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 }
+    usage
   };
 };
 
-const defaultEmbed = async ({ userId, texts }) => {
+const defaultEmbed = async ({ userId, texts, purpose }) => {
   if (!enabled) throw new AiNotConfiguredError();
   if (!userId) throw new Error('llmService.embed requires a userId to charge the request to');
   const input = Array.isArray(texts) ? texts : [texts];
   const vectors = input.map(fakeEmbedding);
+  aiCostMeter.record(purpose, input.length);
   return {
     vectors,
     dimensions: vectors.length ? MOCK_DIMENSIONS : 0,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,6 +194,32 @@ simply be asked about again.
 Set `AI_LLM_CATEGORIZATION=false` to switch tier 4 off without giving up
 embeddings and the rest of the AI features.
 
+Both ceilings — the daily budget and the resume limit — are only as good as the
+per-transaction cost they are sized against, and until a real import has run
+that cost is a guess. `aiCostMeter` measures it: every completed request reports
+itself from `llmService`, and `processBatch` logs the total for the run it
+belongs to:
+
+```
+Categorization cost user=… transactions=412 tokens=51004 calls=430 perTransaction=123.8
+  (categorisation-fallback-batch=48200 in 42 calls, categorisation-query=2804 in 412 calls, …)
+```
+
+The breakdown is what makes the line actionable — it says whether the money went
+on the model or on embeddings, and a run is normally dominated by whichever of
+those the last change did not address. Divide a day's allowance by
+`perTransaction` to get the transactions a day can categorise; that number is
+what `AI_LLM_RESUME_LIMIT` should be near, since enqueuing more than a day can
+pay for only marks the surplus outstanding again.
+
+The meter follows the async context rather than being passed down as an
+argument, because three services spend on one run — the classifier embedding the
+corpus, the classifier embedding each query, the categoriser asking the model —
+and a total that missed any of them would be quietly wrong. A before/after
+reading of the per-user counter in `aiBudget` would not work either: the
+low-priority queue runs two jobs at once and the request-driven AI paths share
+the process, so one run would be charged for another's tokens.
+
 Tier 4 is asked in batches, because the category list is almost the entire
 prompt and is identical for every transaction: asking about one transaction
 sends roughly 730 tokens of menu to carry about 20 tokens of question. So


### PR DESCRIPTION
## The problem

Both spend ceilings in this app — `AI_DAILY_TOKEN_BUDGET`, and the
`AI_LLM_RESUME_LIMIT` added in #83 — are sized against a per-transaction cost of
roughly **124 tokens**. That number was never measured. It was inferred from the
batching work, where a fixture set of 12 requests came to 10,680 tokens, and
nothing since has checked it against a real import.

Nothing *could* have checked it. `llmService` logs `tokens=` per call and
`aiBudget` counts a per-user daily total, but nothing added up what a single run
spent — and the run is the unit a ceiling has to be chosen from.

## What this adds

`aiCostMeter` totals the tokens spent inside a piece of work. `llmService`
reports every completed request to it, so a caller cannot spend anything without
it being counted, and `processBatch` logs the total for the run it belongs to:

```
Categorization cost user=… transactions=412 tokens=51004 calls=430 perTransaction=123.8
  (categorisation-fallback-batch=48200 in 42 calls, categorisation-query=2804 in 412 calls,
   categorisation-corpus=1200 in 1 call)
```

The breakdown is the part that makes it actionable: it says whether the money
went on the model or on embeddings. A run of 412 transactions makes 412 separate
query embeddings and 42 batched chat calls, and only this line says which of
those dominates the bill.

Logged only when something was actually spent — with AI unconfigured, which is
every environment that has not set it up, it would otherwise be a line per batch
reporting that nothing happened.

## Why the async context, and not the two simpler options

Three services spend on one run: the classifier embedding the corpus, the
classifier embedding each query, the categoriser asking the model. A total that
missed any of them would be quietly wrong, and threading an accumulator through
all three would only measure the places someone remembered to thread it through.

Reading `aiBudget`'s per-user counter before and after would have been less code
and **wrong**: the low-priority queue runs two jobs at once and the
request-driven AI paths share the process, so one run would be charged for
another's tokens — most likely during a large import, which is exactly when the
number matters. There's a test for that.

## Verification

- Full backend suite: **56 suites, 1091 passing**, 6 pre-existing skips.
- **14 mutations, 14 killed.**

Mutation testing earned its keep twice here:

- Removing the metering from the **real** `llmService` broke nothing — every
  suite mocks that module, so the mock was metering and the real service was
  untested. Now covered directly, with the client stubbed.
- It also showed the first draft of the integration test was measuring less than
  it claimed: embeddings are off by default in the suite, so the run it asserted
  on had only ever spent on chat. The test now exercises all three purposes and
  pins the exact totals.

## Follow-up

The number itself. This makes one real import readable; the ceilings should be
re-set from that line rather than from the estimate they carry today.
