### PR TITLE
Point the scraping queues at the configured Redis

### DIFF
--- a/backend/src/shared/services/__tests__/scrapingQueue.test.js
+++ b/backend/src/shared/services/__tests__/scrapingQueue.test.js
@@ -1,5 +1,3 @@
-const config = require('../../config');
-
 // BullMQ is the thing under test here - what matters is the options the queues
 // and workers are constructed with, not that a real Redis answers.
 jest.mock('bullmq');
@@ -7,32 +5,47 @@ jest.mock('bullmq');
 // setup.js swaps this module out for a stub everywhere else, since no test
 // should reach Redis. This suite is the one place that has to see the real one.
 describe('scrapingQueue wiring', () => {
-  const REMOTE_HOST = 'redis.internal.test';
-  const REMOTE_PORT = '6380';
-  const originalHost = process.env.REDIS_HOST;
-  const originalPort = process.env.REDIS_PORT;
+  const REMOTE = {
+    REDIS_HOST: 'redis.internal.test',
+    REDIS_PORT: '6380',
+    REDIS_PASSWORD: 'a-password-that-must-be-carried-through',
+    REDIS_DB: '3'
+  };
+  const originalEnv = {};
 
   let scrapingQueue;
+  let config;
   let Queue;
   let Worker;
 
   beforeEach(() => {
-    // A host that is deliberately not localhost: the failure this guards
-    // against is a silent fallback to BullMQ's own 127.0.0.1 default, which
-    // looks correct in development and only breaks once Redis lives elsewhere.
-    process.env.REDIS_HOST = REMOTE_HOST;
-    process.env.REDIS_PORT = REMOTE_PORT;
+    // A host that is deliberately not localhost, and credentials that are
+    // deliberately not empty: the failure this guards against is a silent
+    // fallback to BullMQ's own 127.0.0.1 default, which looks correct in
+    // development and only breaks once Redis lives somewhere else.
+    for (const [key, value] of Object.entries(REMOTE)) {
+      originalEnv[key] = process.env[key];
+      process.env[key] = value;
+    }
+
     jest.resetModules();
     ({ Queue, Worker } = require('bullmq'));
+    // Required after the reset so this is the same instance the service reads.
+    // config derives its values from the environment at require time, so a copy
+    // loaded earlier would still describe the old one.
+    config = require('../../config');
     scrapingQueue = jest.requireActual('../scrapingQueue');
   });
 
   afterEach(async () => {
-    await scrapingQueue.shutdown().catch(() => {});
-    if (originalHost === undefined) delete process.env.REDIS_HOST;
-    else process.env.REDIS_HOST = originalHost;
-    if (originalPort === undefined) delete process.env.REDIS_PORT;
-    else process.env.REDIS_PORT = originalPort;
+    // Not wrapped in a catch: a shutdown that starts throwing is something
+    // these tests should report rather than hide.
+    await scrapingQueue.shutdown();
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   });
 
   it('points its queues at the configured Redis rather than localhost', async () => {
@@ -41,7 +54,10 @@ describe('scrapingQueue wiring', () => {
     expect(Queue).toHaveBeenCalled();
     for (const [, options] of Queue.mock.calls) {
       expect(options.connection).toEqual(
-        expect.objectContaining({ host: REMOTE_HOST, port: Number(REMOTE_PORT) })
+        expect.objectContaining({
+          host: REMOTE.REDIS_HOST,
+          port: Number(REMOTE.REDIS_PORT)
+        })
       );
     }
   });
@@ -83,6 +99,10 @@ describe('scrapingQueue wiring', () => {
     await scrapingQueue.initialize();
 
     const [, options] = Queue.mock.calls[0];
+    expect(options.connection.password).toBe(REMOTE.REDIS_PASSWORD);
+    expect(options.connection.db).toBe(Number(REMOTE.REDIS_DB));
+    // Pinned to config as well as to the raw values, so this still holds if
+    // the way credentials reach the queue changes.
     expect(options.connection.password).toBe(config.redis.password);
     expect(options.connection.db).toBe(config.redis.db);
   });

--- a/backend/src/shared/services/__tests__/scrapingQueue.test.js
+++ b/backend/src/shared/services/__tests__/scrapingQueue.test.js
@@ -1,0 +1,89 @@
+const config = require('../../config');
+
+// BullMQ is the thing under test here - what matters is the options the queues
+// and workers are constructed with, not that a real Redis answers.
+jest.mock('bullmq');
+
+// setup.js swaps this module out for a stub everywhere else, since no test
+// should reach Redis. This suite is the one place that has to see the real one.
+describe('scrapingQueue wiring', () => {
+  const REMOTE_HOST = 'redis.internal.test';
+  const REMOTE_PORT = '6380';
+  const originalHost = process.env.REDIS_HOST;
+  const originalPort = process.env.REDIS_PORT;
+
+  let scrapingQueue;
+  let Queue;
+  let Worker;
+
+  beforeEach(() => {
+    // A host that is deliberately not localhost: the failure this guards
+    // against is a silent fallback to BullMQ's own 127.0.0.1 default, which
+    // looks correct in development and only breaks once Redis lives elsewhere.
+    process.env.REDIS_HOST = REMOTE_HOST;
+    process.env.REDIS_PORT = REMOTE_PORT;
+    jest.resetModules();
+    ({ Queue, Worker } = require('bullmq'));
+    scrapingQueue = jest.requireActual('../scrapingQueue');
+  });
+
+  afterEach(async () => {
+    await scrapingQueue.shutdown().catch(() => {});
+    if (originalHost === undefined) delete process.env.REDIS_HOST;
+    else process.env.REDIS_HOST = originalHost;
+    if (originalPort === undefined) delete process.env.REDIS_PORT;
+    else process.env.REDIS_PORT = originalPort;
+  });
+
+  it('points its queues at the configured Redis rather than localhost', async () => {
+    await scrapingQueue.initialize();
+
+    expect(Queue).toHaveBeenCalled();
+    for (const [, options] of Queue.mock.calls) {
+      expect(options.connection).toEqual(
+        expect.objectContaining({ host: REMOTE_HOST, port: Number(REMOTE_PORT) })
+      );
+    }
+  });
+
+  it('does not pass the connection under Bull v3\'s name, which BullMQ ignores', async () => {
+    await scrapingQueue.initialize();
+
+    // `redis` was Bull v3's option. BullMQ neither reads nor rejects it, so a
+    // queue configured that way connects to 127.0.0.1:6379 and every job sits
+    // unqueued behind a connection that is refused - with no error to say so.
+    for (const [, options] of Queue.mock.calls) {
+      expect(options).not.toHaveProperty('redis');
+    }
+  });
+
+  it('gives the workers the same Redis the queues were given', async () => {
+    await scrapingQueue.startProcessing();
+
+    expect(Worker).toHaveBeenCalled();
+    const queueConnections = Queue.mock.calls.map(([, options]) => options.connection);
+    // Producers and consumers disagreeing is the quiet version of this bug:
+    // jobs land in one Redis and are waited for in another, and nothing errors.
+    // Worker takes the processor as its second argument, so options are third.
+    for (const [, , options] of Worker.mock.calls) {
+      expect(queueConnections).toContainEqual(options.connection);
+    }
+  });
+
+  it('builds every configured priority queue', async () => {
+    await scrapingQueue.initialize();
+
+    const names = Queue.mock.calls.map(([name]) => name);
+    expect(names).toEqual(
+      expect.arrayContaining(['scraping-high', 'scraping-normal', 'scraping-low'])
+    );
+  });
+
+  it('carries the credentials from config through to the connection', async () => {
+    await scrapingQueue.initialize();
+
+    const [, options] = Queue.mock.calls[0];
+    expect(options.connection.password).toBe(config.redis.password);
+    expect(options.connection.db).toBe(config.redis.db);
+  });
+});

--- a/backend/src/shared/services/scrapingQueue.js
+++ b/backend/src/shared/services/scrapingQueue.js
@@ -69,8 +69,14 @@ class ScrapingQueueService {
     try {
       // Create queues for different priorities
       for (const [queueName, config] of Object.entries(this.queueConfigs)) {
+        // `connection`, not `redis`: the latter is Bull v3's option name, and
+        // BullMQ ignores unknown keys rather than rejecting them. A queue built
+        // with `redis` silently falls back to BullMQ's own default of
+        // 127.0.0.1:6379 and can never reach a remote Redis - which in
+        // production meant every scrape sat unqueued behind a connection that
+        // was refused forever.
         const queue = new Queue(queueName, {
-          redis: this.redisConfig,
+          connection: this.redisConfig,
           defaultJobOptions: config.defaultJobOptions
         });
 


### PR DESCRIPTION
Adding a bank account in production logged "Initiating first sync" and then did nothing at all. The scraping job was never enqueued and no transactions were ever imported.

## What was wrong

The queues were constructed with Bull v3's option name:

```js
new Queue(queueName, { redis: this.redisConfig, ... })
```

BullMQ reads `connection`, and ignores keys it does not recognise, so each queue was built against BullMQ's own default of `127.0.0.1:6379`. There is no Redis there - the real one is at `REDIS_HOST=gerifinancial-redis`.

The `Worker` a few lines below already used `connection`, which is why the production log only ever showed queue errors and never worker errors.

## Why it was invisible

`/health` reported `"redis":"connected"` throughout, because the app's own client uses `config.redis` correctly. Only the queues were pointed at the wrong host.

The failure then hid itself:

- the queue logged `connect ECONNREFUSED 127.0.0.1:6379` every 20s and continued
- `initialize()` hung on its first Redis command (`getActive()`, cleaning stale jobs), so "Scraping queue service initialized successfully" was never logged
- because `initialize()` never returned, `startProcessing()` was never reached and **no worker was ever created**
- `addJob` then hung too, so no "Added job" line either

Production evidence - an account added at 22:54:50 and still unscraped two hours later:

```
22:54:50 info: Initiating first sync for new bank account: Main Checking
22:54:50 info: Created scraping queue: scraping-high with concurrency: 3
22:54:50 info: Scheduled scraping job for account 6a74e686032a4ef54a5a23ff
        (nothing further - no cleanup, no "initialized successfully",
         no worker, no "Added job")
```

## The fix

One word: `redis` -> `connection`. This also restores the `maxRetriesPerRequest: 3` that was already in the config and had never taken effect, so a future misconfiguration fails a command instead of hanging on it forever.

## Tests

This service had no tests at all, which is how the typo survived. The new suite pins the connection to a host that is deliberately **not** localhost, so a regression cannot pass by accidentally agreeing with BullMQ's default in development.

Verified by reintroducing the bug: 4 of the 5 new tests fail with `redis:` and all 5 pass with `connection:`.

Backend suite: 59 suites, 1197 passed, 6 skipped.

## After deploy

No manual step needed. Per-strategy sync status defaults to `never`, so the scheduler's startup check (10s after boot) will queue the pending account automatically.
