### PR TITLE
Fix onboarding card detection and import one year

### DIFF
--- a/backend/src/banking/__tests__/BankAccount.test.js
+++ b/backend/src/banking/__tests__/BankAccount.test.js
@@ -137,6 +137,21 @@ describe('BankAccount Model', () => {
         verbose: false
       });
     });
+
+    it('should default first-time scraping to the past year', async () => {
+      const before = new Date();
+      before.setMonth(before.getMonth() - 12);
+      const account = await BankAccount.create(mockAccount);
+      const defaultStartDate = account.getDefaultStartDate();
+      const after = new Date();
+      after.setMonth(after.getMonth() - 12);
+
+      expect(account.scrapingConfig.options.monthsBack).toBe(12);
+      expect(account.scrapingConfig.options.startDate.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(account.scrapingConfig.options.startDate.getTime()).toBeLessThanOrEqual(after.getTime());
+      expect(defaultStartDate.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(defaultStartDate.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
   });
 
   describe('Default Currency', () => {

--- a/backend/src/banking/models/BankAccount.js
+++ b/backend/src/banking/models/BankAccount.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const credentialEncryption = require('../../shared/services/credentialEncryption');
-const { resolveStartDate } = require('../utils/scraperDates');
+const { resolveStartDate, DEFAULT_LOOKBACK_MONTHS } = require('../utils/scraperDates');
 const logger = require('../../shared/utils/logger');
 const { OTP_BANKS } = require('../constants/enums');
 
@@ -180,18 +180,14 @@ const bankAccountSchema = new mongoose.Schema({
     options: {
       startDate: {
         type: Date,
-        default: () => {
-          const date = new Date();
-          date.setMonth(date.getMonth() - 6); // Default to 6 months ago for first scraping
-          return date;
-        }
+        default: () => resolveStartDate(null)
       },
       // Number of months of transactions to fetch
       monthsBack: {
         type: Number,
         min: 1,
         max: 12,
-        default: 6
+        default: DEFAULT_LOOKBACK_MONTHS
       }
     }
   }

--- a/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
+++ b/backend/src/banking/services/__tests__/transactionCategorizationService.test.js
@@ -3,6 +3,7 @@ const transactionCategorizationService = require('../transactionCategorizationSe
 const categoryMappingService = require('../categoryMappingService');
 const transactionClassifier = require('../transactionClassifier');
 const llmCategorizer = require('../llmCategorizer');
+const scrapingEvents = require('../scrapingEvents');
 const scrapingQueue = require('../../../shared/services/scrapingQueue');
 const sseService = require('../../../shared/services/sseService');
 const { Transaction, Category, SubCategory } = require('../../models');
@@ -74,6 +75,43 @@ describe('transactionCategorizationService', () => {
   });
 
   describe('processBatch', () => {
+    it('reports a final-attempt batch failure to internal consumers', async () => {
+      jest.spyOn(transactionClassifier, 'forUser').mockRejectedValue(new Error('corpus unavailable'));
+      const emit = jest.spyOn(scrapingEvents, 'emit').mockImplementation(() => true);
+
+      await expect(transactionCategorizationService.processBatch({
+        userId: user._id,
+        transactionIds: [new mongoose.Types.ObjectId()]
+      }, {
+        attemptsMade: 1,
+        opts: { attempts: 2 }
+      })).rejects.toThrow('corpus unavailable');
+
+      expect(emit).toHaveBeenCalledWith('categorization:failed', {
+        userId: user._id.toString(),
+        total: 1,
+        error: 'corpus unavailable'
+      });
+    });
+
+    it('does not report failure while the queue still has a retry left', async () => {
+      jest.spyOn(transactionClassifier, 'forUser').mockRejectedValue(new Error('try again'));
+      const emit = jest.spyOn(scrapingEvents, 'emit').mockImplementation(() => true);
+
+      await expect(transactionCategorizationService.processBatch({
+        userId: user._id,
+        transactionIds: [new mongoose.Types.ObjectId()]
+      }, {
+        attemptsMade: 0,
+        opts: { attempts: 2 }
+      })).rejects.toThrow('try again');
+
+      expect(emit).not.toHaveBeenCalledWith(
+        'categorization:failed',
+        expect.anything()
+      );
+    });
+
     it('loads the corpus once for the whole batch', async () => {
       const forUser = jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
       const transactions = await Promise.all([makeTransaction(), makeTransaction(), makeTransaction()]);
@@ -322,6 +360,25 @@ describe('transactionCategorizationService', () => {
       const complete = emit.mock.calls.find(([, type]) => type === 'categorization:completed');
       expect(complete).toBeDefined();
       expect(complete[2]).toMatchObject({ total: 1 });
+    });
+
+    it('tells internal consumers only after the categorization batch is done', async () => {
+      jest.spyOn(transactionClassifier, 'forUser').mockResolvedValue(null);
+      const emit = jest.spyOn(scrapingEvents, 'emit').mockImplementation(() => true);
+      const transaction = await makeTransaction();
+
+      await transactionCategorizationService.processBatch({
+        userId: user._id,
+        transactionIds: [transaction._id]
+      });
+
+      expect(emit).toHaveBeenCalledWith(
+        'categorization:completed',
+        expect.objectContaining({
+          userId: user._id.toString(),
+          total: 1
+        })
+      );
     });
 
     // Clients register under the string form of the id, so an ObjectId here

--- a/backend/src/banking/services/bankScraperService.js
+++ b/backend/src/banking/services/bankScraperService.js
@@ -53,7 +53,7 @@ class BankScraperService {
   }
 
   createScraper(bankAccount, options = {}) {
-    // Get smart start date from bank account (uses lastScraped if available, otherwise 6 months back)
+    // Get smart start date from bank account (uses lastScraped if available, otherwise 12 months back)
     const {
       startDate = resolveStartDate(bankAccount.lastScraped),
       showBrowser = false,

--- a/backend/src/banking/services/transactionCategorizationService.js
+++ b/backend/src/banking/services/transactionCategorizationService.js
@@ -2,6 +2,7 @@ const { Transaction } = require('../models');
 const categoryMappingService = require('./categoryMappingService');
 const transactionClassifier = require('./transactionClassifier');
 const llmCategorizer = require('./llmCategorizer');
+const scrapingEvents = require('./scrapingEvents');
 const scrapingQueue = require('../../shared/services/scrapingQueue');
 const sseService = require('../../shared/services/sseService');
 const aiCostMeter = require('../../shared/services/ai/aiCostMeter');
@@ -94,9 +95,27 @@ class TransactionCategorizationService {
    * every call logged its own tokens and nothing added them up over a run.
    */
   async processBatch({ userId, transactionIds }, job) {
-    const { result, cost } = await aiCostMeter.measure(
-      () => this.runBatch({ userId, transactionIds }, job)
-    );
+    let measured;
+    try {
+      measured = await aiCostMeter.measure(
+        () => this.runBatch({ userId, transactionIds }, job)
+      );
+    } catch (error) {
+      const attempts = job?.opts?.attempts || 1;
+      // Mirrors BullMQ's shouldRetryJob check: attemptsMade is the number that
+      // failed before the attempt currently executing.
+      const isFinalAttempt = !job || job.attemptsMade + 1 >= attempts;
+      if (isFinalAttempt) {
+        scrapingEvents.emit('categorization:failed', {
+          userId: userId.toString(),
+          total: transactionIds.length,
+          error: error.message
+        });
+      }
+      throw error;
+    }
+
+    const { result, cost } = measured;
 
     // Only when something was actually spent. With AI switched off every batch
     // would otherwise log a line saying nothing was spent, and this line exists
@@ -230,6 +249,15 @@ class TransactionCategorizationService {
       `Categorized ${results.categorized}/${transactionIds.length} transactions for user ${userId} ` +
       `(${results.uncategorized} left for the user, ${results.failed} failed)`
     );
+
+    // Internal consumers need the same boundary as the browser: credit-card
+    // detection cannot inspect category-backed payments until this batch has
+    // finished writing those categories.
+    scrapingEvents.emit('categorization:completed', {
+      userId: userIdStr,
+      total: transactionIds.length,
+      ...results
+    });
 
     await this.offerToProjects(userId, userIdStr, categorizedIds);
 

--- a/backend/src/banking/utils/__tests__/scraperDates.test.js
+++ b/backend/src/banking/utils/__tests__/scraperDates.test.js
@@ -1,0 +1,20 @@
+const { resolveStartDate, DEFAULT_LOOKBACK_MONTHS } = require('../scraperDates');
+
+describe('scraperDates', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('defaults first-time scraping to 12 months ago', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-07T12:00:00.000Z'));
+
+    expect(DEFAULT_LOOKBACK_MONTHS).toBe(12);
+    expect(resolveStartDate(null)).toEqual(new Date('2025-08-07T12:00:00.000Z'));
+  });
+
+  it('preserves the last scrape date for incremental imports', () => {
+    const lastScraped = new Date('2026-08-01T12:00:00.000Z');
+
+    expect(resolveStartDate(lastScraped)).toBe(lastScraped);
+  });
+});

--- a/backend/src/banking/utils/scraperDates.js
+++ b/backend/src/banking/utils/scraperDates.js
@@ -1,4 +1,4 @@
-const DEFAULT_LOOKBACK_MONTHS = 6;
+const DEFAULT_LOOKBACK_MONTHS = 12;
 
 /**
  * Resolves the date a scrape should start from. Incremental when the account

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -466,6 +466,59 @@ describe('Onboarding Accounts API', () => {
         .toBeGreaterThan(analyzedAt.getTime());
     });
 
+    it('does not refresh when only an older transaction was categorized after analysis', async () => {
+      const analyzedAt = new Date(Date.now() - 60 * 1000);
+      const oldTransactionDate = new Date();
+      oldTransactionDate.setMonth(oldTransactionDate.getMonth() - 3);
+      const category = await Category.create({
+        name: 'Credit Card',
+        type: 'Transfer',
+        userId: testUser._id
+      });
+
+      await Transaction.create({
+        identifier: 'old-card-payment-after-analysis',
+        userId: testUser._id,
+        accountId: new mongoose.Types.ObjectId(),
+        amount: -2345,
+        currency: 'ILS',
+        date: oldTransactionDate,
+        description: 'Old MAX monthly payment',
+        category: category._id,
+        rawData: { description: 'Old MAX monthly payment' }
+      });
+
+      testUser.onboarding = {
+        isComplete: false,
+        currentStep: 'credit-card-detection',
+        transactionImport: {
+          completed: true,
+          transactionsImported: 150,
+          completedAt: analyzedAt
+        },
+        creditCardDetection: {
+          analyzed: true,
+          analyzedAt,
+          transactionCount: 0,
+          recommendation: 'skip',
+          sampleTransactions: []
+        },
+        completedSteps: ['checking-account', 'transaction-import']
+      };
+      await testUser.save();
+
+      const response = await request(app)
+        .get('/api/onboarding/status')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.creditCardDetection.transactionCount).toBe(0);
+
+      const unchangedUser = await User.findById(testUser._id);
+      expect(unchangedUser.onboarding.creditCardDetection.analyzedAt.getTime())
+        .toBe(analyzedAt.getTime());
+    });
+
     it('does not wait forever when a categorization job never finishes', async () => {
       const importCompletedAt = new Date(Date.now() - 16 * 60 * 1000);
       const category = await Category.create({

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -4,7 +4,7 @@ const jwt = require('jsonwebtoken');
 const app = require('../../app');
 const config = require('../../shared/config');
 const { User } = require('../../auth');
-const { BankAccount } = require('../../banking');
+const { BankAccount, Transaction, Category } = require('../../banking');
 const scrapingEvents = require('../../banking/services/scrapingEvents');
 
 // Mock the banking module
@@ -37,6 +37,8 @@ describe('Onboarding Accounts API', () => {
     // Clear collections
     await User.deleteMany({});
     await BankAccount.deleteMany({});
+    await Transaction.deleteMany({});
+    await Category.deleteMany({});
 
     // Create test user
     testUser = await User.create({
@@ -405,6 +407,110 @@ describe('Onboarding Accounts API', () => {
       const { data } = response.body;
       expect(data.currentStep).toBe('checking-account');
       expect(data.isComplete).toBe(false);
+    });
+
+    it('repairs a zero-result card analysis that ran before categorization finished', async () => {
+      const analyzedAt = new Date(Date.now() - 60 * 1000);
+      const accountId = new mongoose.Types.ObjectId();
+      const category = await Category.create({
+        name: 'Credit Card',
+        type: 'Transfer',
+        userId: testUser._id
+      });
+
+      await Transaction.create({
+        identifier: 'card-payment-after-analysis',
+        userId: testUser._id,
+        accountId,
+        amount: -4321,
+        currency: 'ILS',
+        date: new Date(),
+        description: 'MAX monthly payment',
+        category: category._id,
+        rawData: { description: 'MAX monthly payment' }
+      });
+
+      testUser.onboarding = {
+        isComplete: false,
+        currentStep: 'credit-card-detection',
+        transactionImport: {
+          completed: true,
+          transactionsImported: 150,
+          completedAt: analyzedAt
+        },
+        creditCardDetection: {
+          analyzed: true,
+          analyzedAt,
+          transactionCount: 0,
+          recommendation: 'skip',
+          sampleTransactions: []
+        },
+        completedSteps: ['checking-account', 'transaction-import']
+      };
+      await testUser.save();
+
+      const response = await request(app)
+        .get('/api/onboarding/status')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.creditCardDetection.transactionCount).toBe(1);
+      expect(response.body.data.creditCardDetection.recommendation).not.toBe('skip');
+      expect(response.body.data.creditCardDetection.sampleTransactions).toEqual([
+        expect.objectContaining({ description: 'MAX monthly payment', amount: 4321 })
+      ]);
+
+      const repairedUser = await User.findById(testUser._id);
+      expect(repairedUser.onboarding.creditCardDetection.transactionCount).toBe(1);
+      expect(repairedUser.onboarding.creditCardDetection.analyzedAt.getTime())
+        .toBeGreaterThan(analyzedAt.getTime());
+    });
+
+    it('does not wait forever when a categorization job never finishes', async () => {
+      const importCompletedAt = new Date(Date.now() - 16 * 60 * 1000);
+      const category = await Category.create({
+        name: 'Credit Card',
+        type: 'Transfer',
+        userId: testUser._id
+      });
+
+      await Transaction.create({
+        identifier: 'card-payment-after-timeout',
+        userId: testUser._id,
+        accountId: new mongoose.Types.ObjectId(),
+        amount: -1234,
+        currency: 'ILS',
+        date: new Date(),
+        description: 'Isracard monthly payment',
+        category: category._id,
+        rawData: { description: 'Isracard monthly payment' }
+      });
+
+      testUser.onboarding = {
+        isComplete: false,
+        currentStep: 'transaction-import',
+        transactionImport: {
+          completed: true,
+          transactionsImported: 150,
+          completedAt: importCompletedAt
+        },
+        creditCardDetection: {
+          analyzed: false,
+          transactionCount: 0,
+          sampleTransactions: []
+        },
+        completedSteps: ['checking-account', 'transaction-import']
+      };
+      await testUser.save();
+
+      const response = await request(app)
+        .get('/api/onboarding/status')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.currentStep).toBe('credit-card-detection');
+      expect(response.body.data.creditCardDetection.analyzed).toBe(true);
+      expect(response.body.data.creditCardDetection.transactionCount).toBe(1);
     });
   });
 });

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -227,6 +227,139 @@ describe('Onboarding Event Handlers', () => {
       expect(callArgs[1]).toEqual(2);
     });
 
+    it('waits for categorization before deciding whether cards exist', async () => {
+      scrapingEvents.emit('checking-accounts:completed', {
+        strategyName: 'checking-accounts',
+        bankAccountId: checkingAccountId,
+        userId: testUser._id,
+        result: {
+          transactions: {
+            newTransactions: 150,
+            categorizationJobId: 'categorize-150'
+          }
+        }
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      let updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.transactionImport.completed).toBe(true);
+      expect(updatedUser.onboarding.currentStep).toBe('transaction-import');
+      expect(updatedUser.onboarding.creditCardDetection.analyzed).toBe(false);
+      expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
+
+      scrapingEvents.emit('categorization:completed', {
+        userId: testUser._id.toString(),
+        total: 150,
+        categorized: 96,
+        uncategorized: 54,
+        failed: 0
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      updatedUser = await User.findById(testUser._id);
+      expect(creditCardDetectionService.analyzeCreditCardUsage).toHaveBeenCalledWith(
+        testUser._id.toString(),
+        2
+      );
+      expect(updatedUser.onboarding.creditCardDetection.analyzed).toBe(true);
+      expect(updatedUser.onboarding.creditCardDetection.transactionCount).toBe(10);
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-detection');
+    });
+
+    it('does not lose a categorization event that beats the scrape-completion write', async () => {
+      scrapingEvents.emit('checking-accounts:completed', {
+        strategyName: 'checking-accounts',
+        bankAccountId: checkingAccountId,
+        userId: testUser._id,
+        result: {
+          transactions: {
+            newTransactions: 1,
+            categorizationJobId: 'categorize-one'
+          }
+        }
+      });
+
+      // EventEmitter does not await async listeners. A one-row categorization
+      // batch can therefore finish while the completion handler is at its first
+      // database read.
+      scrapingEvents.emit('categorization:completed', {
+        userId: testUser._id.toString(),
+        total: 1,
+        categorized: 1,
+        uncategorized: 0,
+        failed: 0
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(creditCardDetectionService.analyzeCreditCardUsage).toHaveBeenCalledWith(
+        testUser._id.toString(),
+        2
+      );
+      expect(updatedUser.onboarding.creditCardDetection.analyzed).toBe(true);
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-detection');
+    });
+
+    it('does not move onboarding backwards when a late categorization batch finishes', async () => {
+      testUser.onboarding.transactionImport = {
+        completed: true,
+        transactionsImported: 150,
+        completedAt: new Date()
+      };
+      testUser.onboarding.currentStep = 'credit-card-setup';
+      await testUser.save();
+
+      scrapingEvents.emit('categorization:completed', {
+        userId: testUser._id.toString(),
+        total: 20,
+        categorized: 20,
+        uncategorized: 0,
+        failed: 0
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-setup');
+    });
+
+    it('falls back to the available transactions when categorization exhausts its retries', async () => {
+      scrapingEvents.emit('checking-accounts:completed', {
+        strategyName: 'checking-accounts',
+        bankAccountId: checkingAccountId,
+        userId: testUser._id,
+        result: {
+          transactions: {
+            newTransactions: 150,
+            categorizationJobId: 'categorize-150'
+          }
+        }
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+      expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
+
+      scrapingEvents.emit('categorization:failed', {
+        userId: testUser._id.toString(),
+        total: 150,
+        error: 'corpus unavailable'
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(creditCardDetectionService.analyzeCreditCardUsage).toHaveBeenCalledWith(
+        testUser._id.toString(),
+        2
+      );
+      expect(updatedUser.onboarding.creditCardDetection.analyzed).toBe(true);
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-detection');
+    });
+
     it('should complete onboarding if no credit cards detected', async () => {
       // Mock detection with skip recommendation
       creditCardDetectionService.analyzeCreditCardUsage.mockResolvedValue({

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -150,6 +150,38 @@ describe('Onboarding Event Handlers', () => {
         expect(updatedUser.onboarding.transactionImport.scrapingStatus.isActive).not.toBe(true);
       }
     });
+
+    it('does not move onboarding backwards when a later sync starts', async () => {
+      testUser.onboarding = {
+        startedAt: new Date(),
+        checkingAccount: {
+          connected: true,
+          accountId: checkingAccountId,
+          connectedAt: new Date(),
+          bankId: 'hapoalim'
+        },
+        currentStep: 'credit-card-setup',
+        transactionImport: {
+          completed: true,
+          transactionsImported: 150,
+          completedAt: new Date()
+        },
+        completedSteps: ['checking-account', 'transaction-import', 'credit-card-detection']
+      };
+      await testUser.save();
+
+      scrapingEvents.emit('checking-accounts:started', {
+        strategyName: 'checking-accounts',
+        bankAccountId: checkingAccountId,
+        userId: testUser._id
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-setup');
+      expect(updatedUser.onboarding.transactionImport.scrapingStatus.status).toBe('scraping');
+    });
   });
 
   describe('checking-accounts:completed event', () => {
@@ -325,6 +357,39 @@ describe('Onboarding Event Handlers', () => {
       const updatedUser = await User.findById(testUser._id);
       expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
       expect(updatedUser.onboarding.currentStep).toBe('credit-card-setup');
+    });
+
+    it('does not move onboarding backwards when a later checking sync completes', async () => {
+      testUser.onboarding.transactionImport = {
+        completed: true,
+        transactionsImported: 150,
+        completedAt: new Date()
+      };
+      testUser.onboarding.currentStep = 'credit-card-setup';
+      testUser.onboarding.completedSteps = [
+        'checking-account',
+        'transaction-import',
+        'credit-card-detection'
+      ];
+      await testUser.save();
+
+      scrapingEvents.emit('checking-accounts:completed', {
+        strategyName: 'checking-accounts',
+        bankAccountId: checkingAccountId,
+        userId: testUser._id,
+        result: {
+          transactions: {
+            newTransactions: 25
+          }
+        }
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-setup');
+      expect(updatedUser.onboarding.transactionImport.transactionsImported).toBe(25);
+      expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
     });
 
     it('falls back to the available transactions when categorization exhausts its retries', async () => {

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -4,6 +4,7 @@ const auth = require('../../shared/middleware/auth');
 const logger = require('../../shared/utils/logger');
 const { User } = require('../../auth');
 const { bankAccountService } = require('../../banking');
+const onboardingCreditCardDetectionService = require('../services/onboardingCreditCardDetectionService');
 
 /**
  * @route   POST /api/onboarding/checking-account
@@ -289,7 +290,7 @@ router.get('/status', auth, async (req, res) => {
   try {
     const userId = req.user._id || req.user.userId;
     
-    const user = await User.findById(userId)
+    let user = await User.findById(userId)
       .populate('onboarding.checkingAccount.accountId')
       .populate('onboarding.creditCardSetup.creditCardAccounts.accountId');
     
@@ -298,6 +299,12 @@ router.get('/status', auth, async (req, res) => {
         success: false,
         error: 'User not found'
       });
+    }
+
+    if (await onboardingCreditCardDetectionService.refreshIfStale(user)) {
+      user = await User.findById(userId)
+        .populate('onboarding.checkingAccount.accountId')
+        .populate('onboarding.creditCardSetup.creditCardAccounts.accountId');
     }
     
     // Transform old credit card matching data to new format if needed

--- a/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
+++ b/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
@@ -5,6 +5,7 @@ const scrapingEvents = require('../../banking/services/scrapingEvents');
 const logger = require('../../shared/utils/logger');
 
 const DETECTION_WAIT_TIMEOUT_MS = 15 * 60 * 1000;
+const DETECTION_LOOKBACK_MONTHS = 2;
 
 class OnboardingCreditCardDetectionService {
   /**
@@ -26,7 +27,10 @@ class OnboardingCreditCardDetectionService {
     }
 
     logger.info(`Running credit card detection for user ${userId}`);
-    const analysis = await creditCardDetectionService.analyzeCreditCardUsage(userId, 2);
+    const analysis = await creditCardDetectionService.analyzeCreditCardUsage(
+      userId,
+      DETECTION_LOOKBACK_MONTHS
+    );
 
     const updatedUser = await User.findOneAndUpdate(
       eligibility,
@@ -94,9 +98,13 @@ class OnboardingCreditCardDetectionService {
       return false;
     }
 
+    const detectionStartDate = new Date();
+    detectionStartDate.setMonth(detectionStartDate.getMonth() - DETECTION_LOOKBACK_MONTHS);
+
     const categorizedAfterAnalysis = await Transaction.exists({
       userId: user._id,
       category: { $exists: true, $ne: null },
+      date: { $gte: detectionStartDate },
       updatedAt: { $gt: detection.analyzedAt }
     });
 

--- a/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
+++ b/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
@@ -1,0 +1,112 @@
+const { User } = require('../../auth');
+const { Transaction } = require('../../banking');
+const creditCardDetectionService = require('../../banking/services/creditCardDetectionService');
+const scrapingEvents = require('../../banking/services/scrapingEvents');
+const logger = require('../../shared/utils/logger');
+
+const DETECTION_WAIT_TIMEOUT_MS = 15 * 60 * 1000;
+
+class OnboardingCreditCardDetectionService {
+  /**
+   * Analyse the now-categorised checking transactions and advance onboarding.
+   *
+   * The expected-step guard prevents a late queue result from moving someone
+   * backwards after they have already answered the card question.
+   */
+  async complete(userId, expectedSteps = ['transaction-import']) {
+    const eligibility = {
+      _id: userId,
+      'onboarding.isComplete': { $ne: true },
+      'onboarding.transactionImport.completed': true,
+      'onboarding.currentStep': { $in: expectedSteps }
+    };
+
+    if (!await User.exists(eligibility)) {
+      return null;
+    }
+
+    logger.info(`Running credit card detection for user ${userId}`);
+    const analysis = await creditCardDetectionService.analyzeCreditCardUsage(userId, 2);
+
+    const updatedUser = await User.findOneAndUpdate(
+      eligibility,
+      {
+        $set: {
+          'onboarding.creditCardDetection.analyzed': true,
+          'onboarding.creditCardDetection.analyzedAt': new Date(),
+          'onboarding.creditCardDetection.transactionCount': analysis.transactionCount,
+          'onboarding.creditCardDetection.recommendation': analysis.recommendation,
+          'onboarding.creditCardDetection.sampleTransactions': analysis.sampleTransactions.slice(0, 5),
+          'onboarding.currentStep': 'credit-card-detection'
+        }
+      },
+      { new: true }
+    );
+
+    // The user may have answered while the analysis was running.
+    if (!updatedUser) {
+      logger.info(`Credit card detection finished after onboarding moved on for user ${userId}; leaving the newer step intact`);
+      return null;
+    }
+
+    logger.info(
+      `✅ Onboarding: Credit card detection completed for user ${userId} - ` +
+      `recommendation: ${analysis.recommendation}, currentStep: ${updatedUser.onboarding.currentStep}`
+    );
+
+    scrapingEvents.emit('credit-card-detection:completed', {
+      userId,
+      analysis
+    });
+
+    return { analysis, user: updatedUser };
+  }
+
+  /**
+   * Repair the race shipped before detection waited for categorisation.
+   *
+   * A legitimate zero stays stable: it is only stale when a categorised
+   * transaction was written after the zero-result analysis.
+   */
+  async refreshIfStale(user) {
+    const onboarding = user?.onboarding;
+    const detection = onboarding?.creditCardDetection;
+    const importCompletedAt = onboarding?.transactionImport?.completedAt;
+
+    const categorizationTimedOut =
+      onboarding?.currentStep === 'transaction-import' &&
+      onboarding?.transactionImport?.completed === true &&
+      detection?.analyzed !== true &&
+      importCompletedAt &&
+      Date.now() - new Date(importCompletedAt).getTime() >= DETECTION_WAIT_TIMEOUT_MS;
+
+    if (categorizationTimedOut) {
+      logger.warn(`Credit card detection waited more than 15 minutes for categorization for user ${user._id}; using the transactions available now`);
+      return Boolean(await this.complete(user._id, ['transaction-import']));
+    }
+
+    if (
+      onboarding?.currentStep !== 'credit-card-detection' ||
+      detection?.analyzed !== true ||
+      detection?.transactionCount !== 0 ||
+      !detection?.analyzedAt
+    ) {
+      return false;
+    }
+
+    const categorizedAfterAnalysis = await Transaction.exists({
+      userId: user._id,
+      category: { $exists: true, $ne: null },
+      updatedAt: { $gt: detection.analyzedAt }
+    });
+
+    if (!categorizedAfterAnalysis) {
+      return false;
+    }
+
+    logger.info(`Refreshing stale credit card detection for user ${user._id} after categorization completed`);
+    return Boolean(await this.complete(user._id, ['credit-card-detection']));
+  }
+}
+
+module.exports = new OnboardingCreditCardDetectionService();

--- a/backend/src/onboarding/services/onboardingEventHandlers.js
+++ b/backend/src/onboarding/services/onboardingEventHandlers.js
@@ -1,6 +1,10 @@
 const { User } = require('../../auth');
 const { BankAccount, Transaction, CreditCard, scrapingEvents, creditCardDetectionService } = require('../../banking');
+const onboardingCreditCardDetectionService = require('./onboardingCreditCardDetectionService');
 const logger = require('../../shared/utils/logger');
+
+const CATEGORIZATION_HANDOFF_RETRIES = 10;
+const CATEGORIZATION_HANDOFF_DELAY_MS = 100;
 
 /**
  * Event handlers for onboarding-specific scraping events
@@ -28,6 +32,11 @@ class OnboardingEventHandlers {
 
     // Listen for checking-accounts strategy failure
     scrapingEvents.on('checking-accounts:failed', this.handleCheckingAccountsFailed.bind(this));
+
+    // Credit-card payments are category-backed, so detection has to wait for
+    // the queued categorisation batch rather than the scrape itself.
+    scrapingEvents.on('categorization:completed', this.handleCategorizationCompleted.bind(this));
+    scrapingEvents.on('categorization:failed', this.handleCategorizationFailed.bind(this));
 
     // Listen for credit card scraping completion to trigger matching
     scrapingEvents.on('credit-cards:completed', this.handleCreditCardsCompleted.bind(this));
@@ -157,12 +166,9 @@ class OnboardingEventHandlers {
       
       // Handle onboarding checking account completion
       if (isOnboardingCheckingAccount && !isOnboardingComplete) {
-        // Run credit card detection
-        logger.info(`Running credit card detection for user ${userId}`);
-        const analysis = await creditCardDetectionService.analyzeCreditCardUsage(userId, 2);
-        
-        // Update new onboarding structure - always show detection step first
-        const updateResult = await User.findByIdAndUpdate(
+        const categorizationPending = Boolean(result.transactions?.categorizationJobId);
+
+        await User.findByIdAndUpdate(
           userId,
           {
             $set: {
@@ -173,12 +179,7 @@ class OnboardingEventHandlers {
               'onboarding.transactionImport.scrapingStatus.status': 'complete',
               'onboarding.transactionImport.scrapingStatus.progress': 100,
               'onboarding.transactionImport.scrapingStatus.message': `Import complete! ${newTransactions} transactions imported.`,
-              'onboarding.creditCardDetection.analyzed': true,
-              'onboarding.creditCardDetection.analyzedAt': new Date(),
-              'onboarding.creditCardDetection.transactionCount': analysis.transactionCount,
-              'onboarding.creditCardDetection.recommendation': analysis.recommendation,
-              'onboarding.creditCardDetection.sampleTransactions': analysis.sampleTransactions.slice(0, 5),
-              'onboarding.currentStep': 'credit-card-detection' // Always show detection UI first
+              'onboarding.currentStep': 'transaction-import'
             },
             $addToSet: {
               'onboarding.completedSteps': 'transaction-import'
@@ -186,14 +187,12 @@ class OnboardingEventHandlers {
           },
           { new: true }
         );
-        
-        logger.info(`✅ Onboarding: Credit card detection completed for user ${userId} - recommendation: ${analysis.recommendation}, currentStep: ${updateResult.onboarding.currentStep}, isActive: ${updateResult.onboarding.transactionImport.scrapingStatus.isActive}`);
-        
-        // Emit credit card detection completed event
-        scrapingEvents.emit('credit-card-detection:completed', {
-          userId,
-          analysis
-        });
+
+        if (categorizationPending) {
+          logger.info(`Onboarding: Waiting for categorization job ${result.transactions.categorizationJobId} before credit card detection for user ${userId}`);
+        } else {
+          await onboardingCreditCardDetectionService.complete(userId);
+        }
       }
       
       // Handle onboarding credit card account completion
@@ -209,7 +208,7 @@ class OnboardingEventHandlers {
           logger.info(`Account ${bankAccountId} completed but not the currently tracked account (${processingAccountId}), skipping matching`);
           return;
         }
-        
+
         logger.info(`Processing account ${bankAccountId} completed, running payment matching for user ${userId}`);
 
         // Get all credit cards for this user
@@ -500,6 +499,51 @@ class OnboardingEventHandlers {
       logger.error(`❌ Onboarding: Stack trace:`, error.stack);
       // Don't throw - this is async post-processing
     }
+  }
+
+  async handleCategorizationCompleted(data) {
+    const { userId } = data;
+
+    try {
+      await this.completeCreditCardDetectionAfterCategorization(userId);
+    } catch (error) {
+      logger.error(`Onboarding: Failed credit card detection after categorization for user ${userId}:`, error);
+    }
+  }
+
+  async handleCategorizationFailed(data) {
+    const { userId, error } = data;
+    logger.warn(`Onboarding: Categorization exhausted its retries for user ${userId}; detecting cards from the transactions available now: ${error}`);
+
+    try {
+      await this.completeCreditCardDetectionAfterCategorization(userId);
+    } catch (detectionError) {
+      logger.error(`Onboarding: Failed fallback credit card detection for user ${userId}:`, detectionError);
+    }
+  }
+
+  async completeCreditCardDetectionAfterCategorization(userId) {
+    for (let attempt = 0; attempt < CATEGORIZATION_HANDOFF_RETRIES; attempt += 1) {
+      const completed = await onboardingCreditCardDetectionService.complete(userId);
+      if (completed) return completed;
+
+      const user = await User.findById(userId)
+        .select('onboarding.currentStep onboarding.transactionImport.completed')
+        .lean();
+
+      const scrapeCompletionStillWriting =
+        user?.onboarding?.currentStep === 'transaction-import' &&
+        user?.onboarding?.transactionImport?.completed !== true;
+
+      if (!scrapeCompletionStillWriting) {
+        return null;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, CATEGORIZATION_HANDOFF_DELAY_MS));
+    }
+
+    logger.warn(`Onboarding: Categorization completed before the import state settled for user ${userId}; status polling will retry detection`);
+    return null;
   }
 
   /**

--- a/backend/src/onboarding/services/onboardingEventHandlers.js
+++ b/backend/src/onboarding/services/onboardingEventHandlers.js
@@ -5,6 +5,7 @@ const logger = require('../../shared/utils/logger');
 
 const CATEGORIZATION_HANDOFF_RETRIES = 10;
 const CATEGORIZATION_HANDOFF_DELAY_MS = 100;
+const IMPORT_RELATED_STEPS = ['checking-account', 'transaction-import'];
 
 /**
  * Event handlers for onboarding-specific scraping events
@@ -94,12 +95,12 @@ class OnboardingEventHandlers {
               'onboarding.transactionImport.scrapingStatus.isActive': true,
               'onboarding.transactionImport.scrapingStatus.status': 'scraping',
               'onboarding.transactionImport.scrapingStatus.progress': 50,
-              'onboarding.transactionImport.scrapingStatus.message': 'Importing transactions...',
-              'onboarding.currentStep': 'transaction-import'
+              'onboarding.transactionImport.scrapingStatus.message': 'Importing transactions...'
             }
           },
           { new: true }
         );
+        await this.advanceToTransactionImportIfEligible(userId);
         logger.info(`✅ Onboarding: Updated onboarding scraping status for checking account ${bankAccountId} - isActive: ${updateResult.onboarding.transactionImport.scrapingStatus.isActive}`);
       }
       
@@ -108,6 +109,20 @@ class OnboardingEventHandlers {
       logger.error(`❌ Onboarding: Failed to set initial scraping status for account ${bankAccountId}:`, error.message);
       logger.error(error.stack);
     }
+  }
+
+  async advanceToTransactionImportIfEligible(userId) {
+    return User.updateOne(
+      {
+        _id: userId,
+        'onboarding.currentStep': { $in: IMPORT_RELATED_STEPS }
+      },
+      {
+        $set: {
+          'onboarding.currentStep': 'transaction-import'
+        }
+      }
+    );
   }
 
   /**
@@ -178,8 +193,7 @@ class OnboardingEventHandlers {
               'onboarding.transactionImport.scrapingStatus.isActive': false,
               'onboarding.transactionImport.scrapingStatus.status': 'complete',
               'onboarding.transactionImport.scrapingStatus.progress': 100,
-              'onboarding.transactionImport.scrapingStatus.message': `Import complete! ${newTransactions} transactions imported.`,
-              'onboarding.currentStep': 'transaction-import'
+              'onboarding.transactionImport.scrapingStatus.message': `Import complete! ${newTransactions} transactions imported.`
             },
             $addToSet: {
               'onboarding.completedSteps': 'transaction-import'
@@ -187,6 +201,7 @@ class OnboardingEventHandlers {
           },
           { new: true }
         );
+        await this.advanceToTransactionImportIfEligible(userId);
 
         if (categorizationPending) {
           logger.info(`Onboarding: Waiting for categorization job ${result.transactions.categorizationJobId} before credit card detection for user ${userId}`);

--- a/backend/src/onboarding/services/onboardingTransactionService.js
+++ b/backend/src/onboarding/services/onboardingTransactionService.js
@@ -150,7 +150,7 @@ class OnboardingTransactionService {
         status: 'scraping',
         stage: 'scraping',
         progress: 15,
-        message: 'Importing and processing data from the last 6 months...'
+        message: 'Importing and processing data from the past year...'
       });
 
       // Perform comprehensive data sync using dataSyncService

--- a/frontend/src/components/onboarding/chat/__tests__/script.test.ts
+++ b/frontend/src/components/onboarding/chat/__tests__/script.test.ts
@@ -80,6 +80,7 @@ describe('buildScript', () => {
   it('opens by asking for the checking account', () => {
     const script = buildScript(baseStatus());
 
+    expect(textOf(script)).toContain('past year of transactions');
     expect(cardsOf(script)).toEqual(['checking-account']);
     expect(script.waiting).toBe(false);
   });
@@ -107,6 +108,21 @@ describe('buildScript', () => {
     const script = buildScript(imported());
 
     expect(textOf(script)).toContain('1,432 transactions');
+  });
+
+  it('describes an empty import using the one-year window', () => {
+    const script = buildScript(
+      imported({
+        transactionImport: {
+          completed: true,
+          transactionsImported: 0,
+          completedAt: '2026-01-01T00:05:00Z',
+          scrapingStatus: { isActive: false, status: 'complete', progress: 100, message: null, error: null }
+        }
+      })
+    );
+
+    expect(textOf(script)).toContain('did not find any transactions in the past year');
   });
 
   it('waits with no card while the detection is still running', () => {

--- a/frontend/src/components/onboarding/chat/cards/ImportProgressCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/ImportProgressCard.tsx
@@ -71,7 +71,7 @@ const describeStage = (scraping?: { status: string | null; message: string | nul
       return {
         icon: <DownloadIcon color="primary" />,
         text: 'Importing Transactions',
-        detail: scraping.message || 'Pulling the last six months across.'
+        detail: scraping.message || 'Pulling the past year across.'
       };
     case 'categorizing':
       return {

--- a/frontend/src/components/onboarding/chat/script.ts
+++ b/frontend/src/components/onboarding/chat/script.ts
@@ -40,7 +40,7 @@ export const buildScript = (status: OnboardingStatus | null): Script => {
   say('greet', "Hi. I'll get GeriFinancial set up with you - it takes a couple of minutes.");
   say(
     'ask-checking',
-    "Let's start with your main checking account. I'll bring in the last six months of transactions so there's something to look at straight away."
+    "Let's start with your main checking account. I'll bring in the past year of transactions so there's something to look at straight away."
   );
 
   // 1. Checking account.
@@ -116,7 +116,7 @@ const describeCheckingAccount = (checking: OnboardingStatus['checkingAccount']):
 };
 
 const describeImport = (count: number): string => {
-  if (!count) return 'That worked. I did not find any transactions in the last six months.';
+  if (!count) return 'That worked. I did not find any transactions in the past year.';
   return `Imported ${count.toLocaleString()} transaction${count === 1 ? '' : 's'} and sorted them into categories.`;
 };
 


### PR DESCRIPTION
The onboarding message saying no card payments exist was produced by a race between transaction persistence and categorization.

## Production evidence

At the time of the incident, the Leumi scrape requested transactions from **2026-01-31 through today**: the former six-month start date (`2026-02-07`) plus the scraper's seven-day overlap.

The relevant order was:

```
09:19:48 checking scrape completed
09:19:49 onboarding recorded 150 imported, 0 categorized
09:19:49 credit-card detection ran against category-backed payments
09:20:49 categorization completed: 96 categorized, 54 left for review
```

Detection only recognizes checking transactions whose populated category is `Credit Card` with type `Transfer`. At 09:19:49 every new transaction still had `category=null`, so onboarding persisted a false zero and never revisited it.

## Changes

- Publish internal `categorization:completed` and final-attempt `categorization:failed` events from the categorization worker.
- Wait for categorization before card detection, with bounded fallbacks for final queue failure, a hung job, and the small-batch event-ordering race.
- Self-heal an already-stored stale zero through `/onboarding/status`, scoped to the same two-month window used by card detection.
- Keep later or duplicate checking-sync start/completion events from moving onboarding backwards after the user advances.
- Extend first-time and per-strategy transaction imports from six months to **12 months**, while retaining the existing seven-day overlap.
- Update onboarding copy and schema defaults to match the one-year import window.

No manual database edit is needed for the current account; loading onboarding after this deploy triggers the repair.

## Tests

Coverage proves the categorization boundary, completion/failure events, stale repair, timeout fallback, event handoff, one-year import defaults, and protection from late sync-event step regression.

Backend: **60 suites / 1,212 passed / 6 skipped**.
Frontend: **27 suites / 310 passed**; eslint, TypeScript, and production build clean.