### PR TITLE
bugfix(onboarding): repair card payment detection

### DIFF
--- a/backend/src/auth/models/User.js
+++ b/backend/src/auth/models/User.js
@@ -109,6 +109,10 @@ const userSchema = new mongoose.Schema({
         type: Date,
         default: null
       },
+      countVerifiedAt: {
+        type: Date,
+        default: null
+      },
       scrapingStatus: {
         isActive: {
           type: Boolean,

--- a/backend/src/banking/services/__tests__/categoryMappingService.test.js
+++ b/backend/src/banking/services/__tests__/categoryMappingService.test.js
@@ -162,6 +162,58 @@ describe('CategoryMappingService', () => {
       expect(transaction.categorizationMethod).toBe(CategorizationMethod.PREVIOUS_DATA);
     });
 
+    it('should allow a transfer category to correct a pre-typed expense', async () => {
+      const creditCardCategory = await Category.create({
+        name: 'Credit Card',
+        type: TransactionType.TRANSFER,
+        keywords: ['כרטיס אשראי', 'ישראכרט'],
+        userId: testUserId
+      });
+      const transaction = await Transaction.create({
+        identifier: 'test-card-payment-pretyped-expense',
+        description: 'כרטיסי אשראי-י',
+        userId: testUserId,
+        accountId: new mongoose.Types.ObjectId(),
+        amount: -10009.46,
+        currency: 'ILS',
+        date: new Date(),
+        type: TransactionType.EXPENSE,
+        rawData: {
+          description: 'כרטיסי אשראי-י',
+          chargedAmount: -10009.46
+        }
+      });
+
+      const updated = await categoryMappingService.attemptAutoCategorization(transaction);
+
+      expect(updated.category._id.toString()).toBe(creditCardCategory._id.toString());
+      expect(updated.category.type).toBe(TransactionType.TRANSFER);
+      expect(updated.type).toBe(TransactionType.TRANSFER);
+    });
+
+    it('should align a pre-typed expense with a matched transfer subcategory', async () => {
+      const transaction = await Transaction.create({
+        identifier: 'test-transfer-subcategory-pretyped-expense',
+        description: 'Bank transfer',
+        userId: testUserId,
+        accountId: new mongoose.Types.ObjectId(),
+        amount: -1000,
+        currency: 'ILS',
+        date: new Date(),
+        type: TransactionType.EXPENSE,
+        rawData: {
+          description: 'Bank transfer',
+          chargedAmount: -1000
+        }
+      });
+
+      const updated = await categoryMappingService.attemptAutoCategorization(transaction);
+
+      expect(updated.category._id.toString()).toBe(testTransferCategory._id.toString());
+      expect(updated.subCategory._id.toString()).toBe(testTransferSubCategory._id.toString());
+      expect(updated.type).toBe(TransactionType.TRANSFER);
+    });
+
     it('should only use income categories for positive amounts using manual categorization', async () => {
       // Create manual categorization entries for both income and expense
       // Create manual categorization entry with a slightly different description

--- a/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
+++ b/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
@@ -1,0 +1,139 @@
+const mongoose = require('mongoose');
+const creditCardDetectionService = require('../creditCardDetectionService');
+const creditCardOnboardingService = require('../creditCardOnboardingService');
+const { Category, Transaction } = require('../../models');
+
+describe('CreditCardDetectionService', () => {
+  let userId;
+
+  beforeEach(async () => {
+    await Promise.all([
+      Category.deleteMany({}),
+      Transaction.deleteMany({})
+    ]);
+    userId = new mongoose.Types.ObjectId();
+  });
+
+  it('recognizes a card settlement even when AI assigned an expense category', async () => {
+    const financialServices = await Category.create({
+      name: 'Financial Services',
+      type: 'Expense',
+      userId
+    });
+    const descriptions = [
+      'כרטיסי אשראי-י',
+      'ישראכרט בע"מ-י',
+      'דיינרס קלוב-י'
+    ];
+    await Transaction.create(descriptions.map((description, index) => ({
+      identifier: `miscategorized-card-payment-${index}`,
+      userId,
+      accountId: new mongoose.Types.ObjectId(),
+      amount: -10009.46,
+      currency: 'ILS',
+      date: new Date(),
+      description,
+      type: 'Expense',
+      category: financialServices._id,
+      categorizationMethod: 'ai',
+      rawData: { description }
+    })));
+
+    const analysis = await creditCardDetectionService.analyzeCreditCardUsage(userId, 2);
+    const paymentMonths = await creditCardOnboardingService.getCreditCardPaymentTransactions(
+      userId,
+      new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+    );
+
+    expect(analysis.transactionCount).toBe(3);
+    expect(analysis.recommendation).toBe('connect');
+    expect(paymentMonths).toEqual([
+      expect.objectContaining({
+        transactionCount: 3,
+        transactions: expect.arrayContaining(
+          descriptions.map(description => expect.objectContaining({ description }))
+        )
+      })
+    ]);
+  });
+
+  it('still recognizes transactions categorized as Credit Card transfers', async () => {
+    const creditCard = await Category.create({
+      name: 'Credit Card',
+      type: 'Transfer',
+      userId
+    });
+    await Transaction.create({
+      identifier: 'categorized-card-payment',
+      userId,
+      accountId: new mongoose.Types.ObjectId(),
+      amount: -1234,
+      currency: 'ILS',
+      date: new Date(),
+      description: 'Monthly settlement',
+      type: 'Transfer',
+      category: creditCard._id,
+      rawData: { description: 'Monthly settlement' }
+    });
+
+    expect((await creditCardDetectionService.analyzeCreditCardUsage(userId, 2)).transactionCount)
+      .toBe(1);
+  });
+
+  it('does not treat an unrelated financial-services expense as a card payment', async () => {
+    const financialServices = await Category.create({
+      name: 'Financial Services',
+      type: 'Expense',
+      userId
+    });
+    await Transaction.create({
+      identifier: 'ordinary-financial-service',
+      userId,
+      accountId: new mongoose.Types.ObjectId(),
+      amount: -50,
+      currency: 'ILS',
+      date: new Date(),
+      description: 'Account service fee',
+      type: 'Expense',
+      category: financialServices._id,
+      rawData: { description: 'Account service fee' }
+    });
+
+    expect((await creditCardDetectionService.analyzeCreditCardUsage(userId, 2)).transactionCount)
+      .toBe(0);
+  });
+
+  it('does not mistake a provider-like merchant name for a card settlement', async () => {
+    await Transaction.create({
+      identifier: 'max-stock-purchase',
+      userId,
+      accountId: new mongoose.Types.ObjectId(),
+      amount: -150,
+      currency: 'ILS',
+      date: new Date(),
+      description: 'מקס סטוק',
+      type: 'Expense',
+      rawData: { description: 'מקס סטוק' }
+    });
+
+    expect((await creditCardDetectionService.analyzeCreditCardUsage(userId, 2)).transactionCount)
+      .toBe(0);
+  });
+
+  it('does not mistake a credit-card fee for a card settlement', async () => {
+    await Transaction.create({
+      identifier: 'credit-card-fee',
+      userId,
+      accountId: new mongoose.Types.ObjectId(),
+      amount: -20,
+      currency: 'ILS',
+      date: new Date(),
+      description: 'עמלת כרטיס אשראי',
+      type: 'Expense',
+      rawData: { description: 'עמלת כרטיס אשראי' }
+    });
+
+    expect((await creditCardDetectionService.analyzeCreditCardUsage(userId, 2)).transactionCount)
+      .toBe(0);
+  });
+});

--- a/backend/src/banking/services/categoryMappingService.js
+++ b/backend/src/banking/services/categoryMappingService.js
@@ -4,6 +4,7 @@ const llmCategorizer = require('./llmCategorizer');
 const { enhancedKeywordMatcher } = require('./enhanced-keyword-matching');
 const { CategorizationMethod, TransactionType } = require('../constants/enums');
 const logger = require('../../shared/utils/logger');
+const { isLikelyCreditCardPayment } = require('./creditCardPaymentMatcher');
 
 /**
  * Returned instead of a result when a caller asked for the model tier to be
@@ -32,10 +33,16 @@ class CategoryMappingService {
    * list, so none of them can reach a category the others could not.
    */
   deriveCategoryTypes(transaction) {
-    if (transaction.type) return [transaction.type];
+    if (transaction.type === TransactionType.TRANSFER) {
+      return [TransactionType.TRANSFER];
+    }
+
+    const directionalType = transaction.type ||
+      (transaction.amount < 0 ? TransactionType.EXPENSE : TransactionType.INCOME);
+
     return [
       TransactionType.TRANSFER,
-      transaction.amount < 0 ? TransactionType.EXPENSE : TransactionType.INCOME
+      directionalType
     ];
   }
 
@@ -50,7 +57,7 @@ class CategoryMappingService {
       suggestion.reasoning
     );
 
-    if (!transaction.type) {
+    if (transaction.type !== suggestion.categoryType) {
       transaction.type = suggestion.categoryType;
       await transaction.save();
     }
@@ -204,7 +211,7 @@ class CategoryMappingService {
         
         // Set transaction type based on the category type
         const category = await Category.findById(manualMatch.category);
-        if (category && !transaction.type) {
+        if (category && transaction.type !== category.type) {
           transaction.type = category.type;
           await transaction.save();
         }
@@ -212,6 +219,30 @@ class CategoryMappingService {
         return await Transaction.findById(transaction._id)
           .populate('category')
           .populate('subCategory');
+      }
+
+      if (
+        categoryTypes.includes(TransactionType.TRANSFER) &&
+        isLikelyCreditCardPayment(transaction)
+      ) {
+        const creditCardCategory = await Category.findOne({
+          userId: transaction.userId,
+          name: 'Credit Card',
+          type: TransactionType.TRANSFER
+        });
+
+        if (creditCardCategory) {
+          return await this.applySuggestion(
+            transaction,
+            {
+              categoryId: creditCardCategory._id,
+              subCategoryId: null,
+              categoryType: creditCardCategory.type,
+              reasoning: 'Recognized a credit card settlement from its bank description'
+            },
+            CategorizationMethod.PREVIOUS_DATA
+          );
+        }
       }
 
       // Try keyword-based matching - gather all potential search terms
@@ -280,7 +311,7 @@ class CategoryMappingService {
         );
         
         // Set transaction type based on the category type
-        if (!transaction.type) {
+        if (transaction.type !== categoryMatch.type) {
           transaction.type = categoryMatch.type;
           await transaction.save();
         }
@@ -354,7 +385,7 @@ class CategoryMappingService {
         );
         
         // Set transaction type based on the category type
-        if (!transaction.type) {
+        if (transaction.type !== subCategoryMatch.parentCategory.type) {
           transaction.type = subCategoryMatch.parentCategory.type;
           await transaction.save();
         }
@@ -378,9 +409,7 @@ class CategoryMappingService {
 
       if (suggestion && suggestion.categoryId) {
         const category = await Category.findById(suggestion.categoryId);
-        // A correction belonging to another type would push the transaction into
-        // a category that contradicts its own sign, so drop the suggestion
-        // rather than trust the neighbours over the arithmetic.
+        // Ignore a correction outside the types this transaction is allowed to use.
         if (category && categoryTypes.includes(category.type)) {
           await transaction.categorize(
             suggestion.categoryId,
@@ -389,7 +418,7 @@ class CategoryMappingService {
             suggestion.reasoning
           );
 
-          if (!transaction.type) {
+          if (transaction.type !== category.type) {
             transaction.type = category.type;
             await transaction.save();
           }

--- a/backend/src/banking/services/creditCardDetectionService.js
+++ b/backend/src/banking/services/creditCardDetectionService.js
@@ -3,6 +3,10 @@ const Transaction = require('../models/Transaction');
 const CreditCard = require('../models/CreditCard');
 const User = require('../../auth/models/User');
 const logger = require('../../shared/utils/logger');
+const {
+  likelyPaymentTextQuery,
+  creditCardPaymentMatchStage
+} = require('./creditCardPaymentMatcher');
 
 /**
  * Service for detecting credit card usage from transaction data
@@ -42,12 +46,7 @@ class CreditCardDetectionService {
             as: 'categoryDetails'
           }
         },
-        {
-          $match: {
-            'categoryDetails.name': 'Credit Card',
-            'categoryDetails.type': 'Transfer'
-          }
-        },
+        creditCardPaymentMatchStage(),
         {
           $group: {
             _id: null,
@@ -129,12 +128,7 @@ class CreditCardDetectionService {
             as: 'categoryDetails'
           }
         },
-        {
-          $match: {
-            'categoryDetails.name': 'Credit Card',
-            'categoryDetails.type': 'Transfer'
-          }
-        },
+        creditCardPaymentMatchStage(),
         {
           $group: {
             _id: {
@@ -199,12 +193,7 @@ class CreditCardDetectionService {
             as: 'categoryDetails'
           }
         },
-        {
-          $match: {
-            'categoryDetails.name': 'Credit Card',
-            'categoryDetails.type': 'Transfer'
-          }
-        },
+        creditCardPaymentMatchStage(),
         {
           $count: 'total'
         }
@@ -216,6 +205,17 @@ class CreditCardDetectionService {
       logger.error(`Error checking credit card transactions for user ${userId}:`, error);
       return false;
     }
+  }
+
+  async hasLikelyCreditCardPayments(userId, monthsBack = 2) {
+    const startDate = new Date();
+    startDate.setMonth(startDate.getMonth() - monthsBack);
+
+    return Boolean(await Transaction.exists({
+      userId: new mongoose.Types.ObjectId(userId),
+      date: { $gte: startDate },
+      ...likelyPaymentTextQuery()
+    }));
   }
   
   /**
@@ -389,12 +389,7 @@ class CreditCardDetectionService {
             as: 'categoryDetails'
           }
         },
-        {
-          $match: {
-            'categoryDetails.name': 'Credit Card',
-            'categoryDetails.type': 'Transfer'
-          }
-        },
+        creditCardPaymentMatchStage(),
         {
           $sort: { date: -1 }
         }

--- a/backend/src/banking/services/creditCardOnboardingService.js
+++ b/backend/src/banking/services/creditCardOnboardingService.js
@@ -2,6 +2,7 @@ const CreditCard = require('../models/CreditCard');
 const BankAccount = require('../models/BankAccount');
 const Transaction = require('../models/Transaction');
 const logger = require('../../shared/utils/logger');
+const { creditCardPaymentMatchStage } = require('./creditCardPaymentMatcher');
 const mongoose = require('mongoose');
 
 /**
@@ -141,12 +142,7 @@ class CreditCardOnboardingService {
             as: 'categoryDetails'
           }
         },
-        {
-          $match: {
-            'categoryDetails.name': 'Credit Card',
-            'categoryDetails.type': 'Transfer'
-          }
-        },
+        creditCardPaymentMatchStage(),
         {
           $group: {
             _id: {

--- a/backend/src/banking/services/creditCardPaymentMatcher.js
+++ b/backend/src/banking/services/creditCardPaymentMatcher.js
@@ -1,0 +1,44 @@
+const CARD_PAYMENT_DESCRIPTION_PATTERN =
+  /^\s*(?:כרטיסי?\s*אשראי|ישראכרט(?:\s+בע"?מ)?|דיינרס(?:\s*קלוב)?|ויזה\s*כאל|מקס\s*(?:איט\s*)?פיננסים|כאל|מקס|credit\s*card(?:\s+payment)?)(?:\s*-\s*י)?\s*$/i;
+
+const likelyPaymentTextQuery = () => ({
+  amount: { $lt: 0 },
+  $or: [
+    { description: CARD_PAYMENT_DESCRIPTION_PATTERN },
+    { memo: CARD_PAYMENT_DESCRIPTION_PATTERN },
+    { 'rawData.description': CARD_PAYMENT_DESCRIPTION_PATTERN },
+    { 'rawData.memo': CARD_PAYMENT_DESCRIPTION_PATTERN }
+  ]
+});
+
+const isLikelyCreditCardPayment = transaction =>
+  transaction?.amount < 0 &&
+  [
+    transaction.description,
+    transaction.memo,
+    transaction.rawData?.description,
+    transaction.rawData?.memo
+  ].some(value => typeof value === 'string' && CARD_PAYMENT_DESCRIPTION_PATTERN.test(value));
+
+const creditCardPaymentMatchStage = () => ({
+  $match: {
+    $or: [
+      {
+        categoryDetails: {
+          $elemMatch: {
+            name: 'Credit Card',
+            type: 'Transfer'
+          }
+        }
+      },
+      likelyPaymentTextQuery()
+    ]
+  }
+});
+
+module.exports = {
+  CARD_PAYMENT_DESCRIPTION_PATTERN,
+  likelyPaymentTextQuery,
+  isLikelyCreditCardPayment,
+  creditCardPaymentMatchStage
+};

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -466,6 +466,112 @@ describe('Onboarding Accounts API', () => {
         .toBeGreaterThan(analyzedAt.getTime());
     });
 
+    it('repairs a zero-result analysis when recognizable card payments were miscategorized', async () => {
+      const analyzedAt = new Date();
+      const expenseCategory = await Category.create({
+        name: 'Financial Services',
+        type: 'Expense',
+        userId: testUser._id
+      });
+
+      await Transaction.create({
+        identifier: 'miscategorized-card-payment',
+        userId: testUser._id,
+        accountId: new mongoose.Types.ObjectId(),
+        amount: -10009.46,
+        currency: 'ILS',
+        date: new Date(),
+        description: 'כרטיסי אשראי-י',
+        type: 'Expense',
+        category: expenseCategory._id,
+        categorizationMethod: 'ai',
+        rawData: { description: 'כרטיסי אשראי-י' }
+      });
+
+      testUser.onboarding = {
+        isComplete: false,
+        currentStep: 'credit-card-detection',
+        transactionImport: {
+          completed: true,
+          transactionsImported: 1,
+          completedAt: analyzedAt
+        },
+        creditCardDetection: {
+          analyzed: true,
+          analyzedAt,
+          transactionCount: 0,
+          recommendation: 'skip',
+          sampleTransactions: []
+        },
+        completedSteps: ['checking-account', 'transaction-import']
+      };
+      await testUser.save();
+
+      const response = await request(app)
+        .get('/api/onboarding/status')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.creditCardDetection.transactionCount).toBe(1);
+      expect(response.body.data.creditCardDetection.recommendation).toBe('connect');
+      expect(response.body.data.creditCardDetection.sampleTransactions).toEqual([
+        expect.objectContaining({
+          description: 'כרטיסי אשראי-י',
+          amount: 10009.46
+        })
+      ]);
+    });
+
+    it('repairs an incremental import count to the checking account total', async () => {
+      const accountId = new mongoose.Types.ObjectId();
+      for (let index = 0; index < 3; index += 1) {
+        await Transaction.create({
+          identifier: `imported-total-${index}`,
+          userId: testUser._id,
+          accountId,
+          amount: -(index + 1) * 100,
+          currency: 'ILS',
+          date: new Date(),
+          description: `Imported transaction ${index}`,
+          rawData: { description: `Imported transaction ${index}` }
+        });
+      }
+
+      testUser.onboarding = {
+        isComplete: false,
+        currentStep: 'credit-card-detection',
+        checkingAccount: {
+          connected: true,
+          accountId,
+          connectedAt: new Date(),
+          bankId: 'hapoalim'
+        },
+        transactionImport: {
+          completed: true,
+          transactionsImported: 1,
+          completedAt: new Date()
+        },
+        creditCardDetection: {
+          analyzed: true,
+          analyzedAt: new Date(),
+          transactionCount: 1,
+          recommendation: 'connect',
+          sampleTransactions: []
+        },
+        completedSteps: ['checking-account', 'transaction-import']
+      };
+      await testUser.save();
+
+      const response = await request(app)
+        .get('/api/onboarding/status')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.transactionImport.transactionsImported).toBe(3);
+      expect((await User.findById(testUser._id)).onboarding.transactionImport.transactionsImported)
+        .toBe(3);
+    });
+
     it('does not refresh when only an older transaction was categorized after analysis', async () => {
       const analyzedAt = new Date(Date.now() - 60 * 1000);
       const oldTransactionDate = new Date();

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -562,14 +562,27 @@ describe('Onboarding Accounts API', () => {
       };
       await testUser.save();
 
+      const countDocuments = jest.spyOn(Transaction, 'countDocuments');
       const response = await request(app)
         .get('/api/onboarding/status')
         .set('Authorization', `Bearer ${authToken}`);
 
       expect(response.status).toBe(200);
       expect(response.body.data.transactionImport.transactionsImported).toBe(3);
-      expect((await User.findById(testUser._id)).onboarding.transactionImport.transactionsImported)
-        .toBe(3);
+      const repairedUser = await User.findById(testUser._id);
+      expect(repairedUser.onboarding.transactionImport.transactionsImported).toBe(3);
+      expect(repairedUser.onboarding.transactionImport.countVerifiedAt).toBeTruthy();
+      expect(countDocuments).toHaveBeenCalledTimes(1);
+
+      countDocuments.mockClear();
+      const secondResponse = await request(app)
+        .get('/api/onboarding/status')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(secondResponse.status).toBe(200);
+      expect(secondResponse.body.data.transactionImport.transactionsImported).toBe(3);
+      expect(countDocuments).not.toHaveBeenCalled();
+      countDocuments.mockRestore();
     });
 
     it('does not refresh when only an older transaction was categorized after analysis', async () => {

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -402,6 +402,7 @@ describe('Onboarding Event Handlers', () => {
       const updatedUser = await User.findById(testUser._id);
       expect(updatedUser.onboarding.currentStep).toBe('credit-card-setup');
       expect(updatedUser.onboarding.transactionImport.transactionsImported).toBe(3);
+      expect(updatedUser.onboarding.transactionImport.countVerifiedAt).toBeTruthy();
       expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
     });
 

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -373,13 +373,26 @@ describe('Onboarding Event Handlers', () => {
       ];
       await testUser.save();
 
+      for (let index = 0; index < 3; index += 1) {
+        await Transaction.create({
+          identifier: `existing-checking-transaction-${index}`,
+          userId: testUser._id,
+          accountId: checkingAccountId,
+          amount: -(index + 1) * 100,
+          currency: 'ILS',
+          date: new Date(),
+          description: `Existing transaction ${index}`,
+          rawData: { description: `Existing transaction ${index}` }
+        });
+      }
+
       scrapingEvents.emit('checking-accounts:completed', {
         strategyName: 'checking-accounts',
         bankAccountId: checkingAccountId,
         userId: testUser._id,
         result: {
           transactions: {
-            newTransactions: 25
+            newTransactions: 1
           }
         }
       });
@@ -388,7 +401,7 @@ describe('Onboarding Event Handlers', () => {
 
       const updatedUser = await User.findById(testUser._id);
       expect(updatedUser.onboarding.currentStep).toBe('credit-card-setup');
-      expect(updatedUser.onboarding.transactionImport.transactionsImported).toBe(25);
+      expect(updatedUser.onboarding.transactionImport.transactionsImported).toBe(3);
       expect(creditCardDetectionService.analyzeCreditCardUsage).not.toHaveBeenCalled();
     });
 

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -302,37 +302,44 @@ router.get('/status', auth, async (req, res) => {
     const checkingAccountId =
       user.onboarding?.checkingAccount?.accountId?._id ||
       user.onboarding?.checkingAccount?.accountId;
-    let importCountRefreshed = false;
+    let importCountVerified = false;
 
     await user.populate('onboarding.checkingAccount.accountId');
     await user.populate('onboarding.creditCardSetup.creditCardAccounts.accountId');
 
-    if (user.onboarding?.transactionImport?.completed && checkingAccountId) {
+    if (
+      user.onboarding?.transactionImport?.completed &&
+      !user.onboarding.transactionImport.countVerifiedAt &&
+      checkingAccountId
+    ) {
       const importedTransactions = await Transaction.countDocuments({
         userId,
         accountId: checkingAccountId
       });
       const storedTransactions = user.onboarding.transactionImport.transactionsImported || 0;
 
+      const countVerifiedAt = new Date();
+      const importUpdate = {
+        'onboarding.transactionImport.countVerifiedAt': countVerifiedAt
+      };
+
       if (importedTransactions > storedTransactions) {
         logger.info(
           `Refreshing onboarding import count for user ${userId}: ` +
           `${storedTransactions} -> ${importedTransactions}`
         );
-        await User.updateOne(
-          { _id: userId },
-          {
-            $set: {
-              'onboarding.transactionImport.transactionsImported': importedTransactions
-            }
-          }
-        );
-        importCountRefreshed = true;
+        importUpdate['onboarding.transactionImport.transactionsImported'] = importedTransactions;
       }
+
+      await User.updateOne(
+        { _id: userId },
+        { $set: importUpdate }
+      );
+      importCountVerified = true;
     }
 
     const detectionRefreshed = await onboardingCreditCardDetectionService.refreshIfStale(user);
-    if (importCountRefreshed || detectionRefreshed) {
+    if (importCountVerified || detectionRefreshed) {
       user = await User.findById(userId)
         .populate('onboarding.checkingAccount.accountId')
         .populate('onboarding.creditCardSetup.creditCardAccounts.accountId');

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../shared/middleware/auth');
 const logger = require('../../shared/utils/logger');
 const { User } = require('../../auth');
-const { bankAccountService } = require('../../banking');
+const { bankAccountService, Transaction } = require('../../banking');
 const onboardingCreditCardDetectionService = require('../services/onboardingCreditCardDetectionService');
 
 /**
@@ -290,9 +290,7 @@ router.get('/status', auth, async (req, res) => {
   try {
     const userId = req.user._id || req.user.userId;
     
-    let user = await User.findById(userId)
-      .populate('onboarding.checkingAccount.accountId')
-      .populate('onboarding.creditCardSetup.creditCardAccounts.accountId');
+    let user = await User.findById(userId);
     
     if (!user) {
       return res.status(404).json({
@@ -301,7 +299,40 @@ router.get('/status', auth, async (req, res) => {
       });
     }
 
-    if (await onboardingCreditCardDetectionService.refreshIfStale(user)) {
+    const checkingAccountId =
+      user.onboarding?.checkingAccount?.accountId?._id ||
+      user.onboarding?.checkingAccount?.accountId;
+    let importCountRefreshed = false;
+
+    await user.populate('onboarding.checkingAccount.accountId');
+    await user.populate('onboarding.creditCardSetup.creditCardAccounts.accountId');
+
+    if (user.onboarding?.transactionImport?.completed && checkingAccountId) {
+      const importedTransactions = await Transaction.countDocuments({
+        userId,
+        accountId: checkingAccountId
+      });
+      const storedTransactions = user.onboarding.transactionImport.transactionsImported || 0;
+
+      if (importedTransactions > storedTransactions) {
+        logger.info(
+          `Refreshing onboarding import count for user ${userId}: ` +
+          `${storedTransactions} -> ${importedTransactions}`
+        );
+        await User.updateOne(
+          { _id: userId },
+          {
+            $set: {
+              'onboarding.transactionImport.transactionsImported': importedTransactions
+            }
+          }
+        );
+        importCountRefreshed = true;
+      }
+    }
+
+    const detectionRefreshed = await onboardingCreditCardDetectionService.refreshIfStale(user);
+    if (importCountRefreshed || detectionRefreshed) {
       user = await User.findById(userId)
         .populate('onboarding.checkingAccount.accountId')
         .populate('onboarding.creditCardSetup.creditCardAccounts.accountId');

--- a/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
+++ b/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
@@ -107,12 +107,21 @@ class OnboardingCreditCardDetectionService {
       date: { $gte: detectionStartDate },
       updatedAt: { $gt: detection.analyzedAt }
     });
+    const likelyPaymentsMissed = await creditCardDetectionService.hasLikelyCreditCardPayments(
+      user._id,
+      DETECTION_LOOKBACK_MONTHS
+    );
 
-    if (!categorizedAfterAnalysis) {
+    if (!categorizedAfterAnalysis && !likelyPaymentsMissed) {
       return false;
     }
 
-    logger.info(`Refreshing stale credit card detection for user ${user._id} after categorization completed`);
+    logger.info(
+      `Refreshing stale credit card detection for user ${user._id} ` +
+      (likelyPaymentsMissed
+        ? 'after recognizable card payments were missed'
+        : 'after categorization completed')
+    );
     return Boolean(await this.complete(user._id, ['credit-card-detection']));
   }
 }

--- a/backend/src/onboarding/services/onboardingEventHandlers.js
+++ b/backend/src/onboarding/services/onboardingEventHandlers.js
@@ -158,6 +158,11 @@ class OnboardingEventHandlers {
 
       // Extract transaction count from result
       const newTransactions = result.transactions?.newTransactions || 0;
+      const totalTransactions = await Transaction.countDocuments({
+        userId,
+        accountId: bankAccountId
+      });
+      const importedTransactions = Math.max(newTransactions, totalTransactions);
       
       // Count categorized transactions for this user
       const categorizedCount = await Transaction.countDocuments({
@@ -170,10 +175,10 @@ class OnboardingEventHandlers {
         isActive: false,
         status: 'complete',
         progress: 100,
-        message: `Import complete! ${newTransactions} transactions imported.`,
+        message: `Import complete! ${importedTransactions} transactions imported.`,
         startedAt: bankAccount.scrapingStatus?.startedAt || new Date(),
         lastUpdatedAt: new Date(),
-        transactionsImported: newTransactions,
+        transactionsImported: importedTransactions,
         transactionsCategorized: categorizedCount
       };
 
@@ -188,12 +193,12 @@ class OnboardingEventHandlers {
           {
             $set: {
               'onboarding.transactionImport.completed': true,
-              'onboarding.transactionImport.transactionsImported': newTransactions,
+              'onboarding.transactionImport.transactionsImported': importedTransactions,
               'onboarding.transactionImport.completedAt': new Date(),
               'onboarding.transactionImport.scrapingStatus.isActive': false,
               'onboarding.transactionImport.scrapingStatus.status': 'complete',
               'onboarding.transactionImport.scrapingStatus.progress': 100,
-              'onboarding.transactionImport.scrapingStatus.message': `Import complete! ${newTransactions} transactions imported.`
+              'onboarding.transactionImport.scrapingStatus.message': `Import complete! ${importedTransactions} transactions imported.`
             },
             $addToSet: {
               'onboarding.completedSteps': 'transaction-import'
@@ -345,7 +350,7 @@ class OnboardingEventHandlers {
       await User.findByIdAndUpdate(userId, {
         $set: {
           'onboardingStatus.hasImportedTransactions': true,
-          'onboardingStatus.transactionsImported': newTransactions,
+          'onboardingStatus.transactionsImported': importedTransactions,
           'onboardingStatus.importCompletedAt': new Date(),
           'onboardingStatus.scrapingStatus.isActive': false,
           'onboardingStatus.scrapingStatus.status': 'complete',
@@ -356,7 +361,10 @@ class OnboardingEventHandlers {
         }
       });
       
-      logger.info(`✅ Onboarding: Updated scraping status for account ${bankAccountId} - ${newTransactions} transactions imported, ${categorizedCount} categorized`);
+      logger.info(
+        `✅ Onboarding: Updated scraping status for account ${bankAccountId} - ` +
+        `${importedTransactions} transactions available (${newTransactions} new), ${categorizedCount} categorized`
+      );
     } catch (error) {
       logger.error(`❌ Onboarding: Failed to update scraping status for account ${bankAccountId}:`, error.message);
       logger.error(`❌ Onboarding: Full error details:`, error);

--- a/backend/src/onboarding/services/onboardingEventHandlers.js
+++ b/backend/src/onboarding/services/onboardingEventHandlers.js
@@ -187,6 +187,7 @@ class OnboardingEventHandlers {
       // Handle onboarding checking account completion
       if (isOnboardingCheckingAccount && !isOnboardingComplete) {
         const categorizationPending = Boolean(result.transactions?.categorizationJobId);
+        const importCompletedAt = new Date();
 
         await User.findByIdAndUpdate(
           userId,
@@ -194,7 +195,8 @@ class OnboardingEventHandlers {
             $set: {
               'onboarding.transactionImport.completed': true,
               'onboarding.transactionImport.transactionsImported': importedTransactions,
-              'onboarding.transactionImport.completedAt': new Date(),
+              'onboarding.transactionImport.completedAt': importCompletedAt,
+              'onboarding.transactionImport.countVerifiedAt': importCompletedAt,
               'onboarding.transactionImport.scrapingStatus.isActive': false,
               'onboarding.transactionImport.scrapingStatus.status': 'complete',
               'onboarding.transactionImport.scrapingStatus.progress': 100,


### PR DESCRIPTION
## What Changed
- Persist the total checking-account transaction count during onboarding instead of the latest incremental sync delta, and repair previously stored low totals when status is read.
- Allow Transfer categories to correct pre-typed Expense/Income transactions and keep the transaction type aligned with the selected category.
- Reuse a conservative card-settlement matcher across categorization, onboarding detection, and monthly payment matching, including legacy transactions miscategorized as expenses.
- Refresh an existing false-zero card analysis when recognizable settlement debits are present.

## Why
Production imported 157 checking transactions but onboarding displayed 2 because it stored only the latest sync delta. Recognizable Israeli card settlements were also excluded from the Credit Card transfer category and produced an incorrect recommendation to skip card setup.

## Impact Analysis
- Existing onboarding records self-repair on the next status request without a migration.
- The description fallback is restricted to negative, settlement-shaped records and excludes provider-like merchant names and credit-card fee text.
- No dependency, configuration, or security changes.

## Quality Gates
- Added regression coverage for total import counts, stale false-zero repair, transfer type alignment, legacy provider descriptions, and false positives.
- Backend and frontend repository gates pass.

## Deployment Considerations
No migration or configuration changes are required. After deployment, reopening onboarding status repairs the affected persisted count and card recommendation.