### PR TITLE
enhance(onboarding): suggest detected card providers

### DIFF
--- a/backend/src/auth/models/User.js
+++ b/backend/src/auth/models/User.js
@@ -163,6 +163,17 @@ const userSchema = new mongoose.Schema({
         date: Date,
         description: String,
         amount: Number
+      }],
+      suggestedProviders: [{
+        _id: false,
+        bankId: {
+          type: String,
+          enum: ['visaCal', 'max', 'isracard']
+        },
+        paymentCount: {
+          type: Number,
+          min: 1
+        }
       }]
     },
     

--- a/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
+++ b/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
@@ -23,7 +23,10 @@ describe('CreditCardDetectionService', () => {
     const descriptions = [
       'כרטיסי אשראי-י',
       'ישראכרט בע"מ-י',
-      'דיינרס קלוב-י'
+      'דיינרס קלוב-י',
+      'Isracard monthly payment',
+      'CAL monthly payment',
+      'MAX monthly payment'
     ];
     await Transaction.create(descriptions.map((description, index) => ({
       identifier: `miscategorized-card-payment-${index}`,
@@ -45,11 +48,16 @@ describe('CreditCardDetectionService', () => {
       new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
     );
 
-    expect(analysis.transactionCount).toBe(3);
+    expect(analysis.transactionCount).toBe(6);
     expect(analysis.recommendation).toBe('connect');
+    expect(analysis.suggestedProviders).toEqual([
+      { bankId: 'isracard', paymentCount: 2 },
+      { bankId: 'visaCal', paymentCount: 2 },
+      { bankId: 'max', paymentCount: 1 }
+    ]);
     expect(paymentMonths).toEqual([
       expect.objectContaining({
-        transactionCount: 3,
+        transactionCount: 6,
         transactions: expect.arrayContaining(
           descriptions.map(description => expect.objectContaining({ description }))
         )

--- a/backend/src/banking/services/creditCardDetectionService.js
+++ b/backend/src/banking/services/creditCardDetectionService.js
@@ -5,6 +5,7 @@ const User = require('../../auth/models/User');
 const logger = require('../../shared/utils/logger');
 const {
   likelyPaymentTextQuery,
+  suggestCreditCardProviders,
   creditCardPaymentMatchStage
 } = require('./creditCardPaymentMatcher');
 
@@ -59,7 +60,10 @@ class CreditCardDetectionService {
               $push: {
                 date: '$date',
                 amount: '$amount',
-                description: '$description'
+                description: '$description',
+                memo: '$memo',
+                rawDescription: '$rawData.description',
+                rawMemo: '$rawData.memo'
               }
             }
           }
@@ -83,6 +87,7 @@ class CreditCardDetectionService {
         monthlyAverage: monthlyBreakdown.length > 0 ? 
           Math.round(transactionData?.count / monthlyBreakdown.length) || 0 : 0,
         recommendation: this.generateRecommendation(transactionData, monthlyBreakdown),
+        suggestedProviders: suggestCreditCardProviders(transactionData?.transactions),
         analysisDate: new Date(),
         lookbackMonths: monthsBack,
         // All transactions for user confidence (sorted by date)

--- a/backend/src/banking/services/creditCardPaymentMatcher.js
+++ b/backend/src/banking/services/creditCardPaymentMatcher.js
@@ -1,5 +1,20 @@
 const CARD_PAYMENT_DESCRIPTION_PATTERN =
-  /^\s*(?:כרטיסי?\s*אשראי|ישראכרט(?:\s+בע"?מ)?|דיינרס(?:\s*קלוב)?|ויזה\s*כאל|מקס\s*(?:איט\s*)?פיננסים|כאל|מקס|credit\s*card(?:\s+payment)?)(?:\s*-\s*י)?\s*$/i;
+  /^\s*(?:כרטיסי?\s*אשראי|ישראכרט(?:\s+בע"?מ)?|דיינרס(?:\s*קלוב)?|ויזה\s*כאל|מקס\s*(?:איט\s*)?פיננסים|כאל|מקס|credit\s*card(?:\s+payment)?|isracard(?:\s+monthly\s+payment)?|diners(?:\s+club)?(?:\s+monthly\s+payment)?|visa\s*cal(?:\s+monthly\s+payment)?|(?:cal|max)\s+monthly\s+payment)(?:\s*-\s*י)?\s*$/i;
+
+const CREDIT_CARD_PROVIDER_HINTS = [
+  { bankId: 'isracard', pattern: /ישראכרט|\bisracard\b/i },
+  { bankId: 'visaCal', pattern: /דיינרס|ויזה\s*כאל|^\s*כאל(?:\s*-\s*י)?\s*$|\bdiners(?:\s+club)?\b|\bvisa\s*cal\b|\bcal\s+monthly\s+payment\b/i },
+  { bankId: 'max', pattern: /מקס\s*(?:איט\s*)?פיננסים|^\s*מקס(?:\s*-\s*י)?\s*$|\bmax\s+monthly\s+payment\b/i }
+];
+
+const paymentTextValues = transaction => [
+  transaction?.description,
+  transaction?.memo,
+  transaction?.rawDescription,
+  transaction?.rawMemo,
+  transaction?.rawData?.description,
+  transaction?.rawData?.memo
+].filter(value => typeof value === 'string');
 
 const likelyPaymentTextQuery = () => ({
   amount: { $lt: 0 },
@@ -13,12 +28,36 @@ const likelyPaymentTextQuery = () => ({
 
 const isLikelyCreditCardPayment = transaction =>
   transaction?.amount < 0 &&
-  [
-    transaction.description,
-    transaction.memo,
-    transaction.rawData?.description,
-    transaction.rawData?.memo
-  ].some(value => typeof value === 'string' && CARD_PAYMENT_DESCRIPTION_PATTERN.test(value));
+  paymentTextValues(transaction)
+    .some(value => CARD_PAYMENT_DESCRIPTION_PATTERN.test(value));
+
+const inferCreditCardProvider = transaction => {
+  const textValues = paymentTextValues(transaction);
+  return CREDIT_CARD_PROVIDER_HINTS.find(
+    hint => textValues.some(value => hint.pattern.test(value))
+  )?.bankId || null;
+};
+
+const suggestCreditCardProviders = transactions => {
+  const counts = new Map();
+
+  for (const transaction of transactions || []) {
+    const bankId = inferCreditCardProvider(transaction);
+    if (bankId) counts.set(bankId, (counts.get(bankId) || 0) + 1);
+  }
+
+  return CREDIT_CARD_PROVIDER_HINTS
+    .map((hint, order) => ({
+      bankId: hint.bankId,
+      paymentCount: counts.get(hint.bankId) || 0,
+      order
+    }))
+    .filter(suggestion => suggestion.paymentCount > 0)
+    .sort((left, right) =>
+      right.paymentCount - left.paymentCount || left.order - right.order
+    )
+    .map(({ bankId, paymentCount }) => ({ bankId, paymentCount }));
+};
 
 const creditCardPaymentMatchStage = () => ({
   $match: {
@@ -40,5 +79,7 @@ module.exports = {
   CARD_PAYMENT_DESCRIPTION_PATTERN,
   likelyPaymentTextQuery,
   isLikelyCreditCardPayment,
+  inferCreditCardProvider,
+  suggestCreditCardProviders,
   creditCardPaymentMatchStage
 };

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -210,6 +210,9 @@ describe('Onboarding Event Handlers', () => {
             description: 'Credit Card Payment',
             amount: 2500
           }
+        ],
+        suggestedProviders: [
+          { bankId: 'isracard', paymentCount: 2 }
         ]
       });
     });
@@ -245,6 +248,9 @@ describe('Onboarding Event Handlers', () => {
       expect(updatedUser.onboarding.creditCardDetection.analyzed).toBe(true);
       expect(updatedUser.onboarding.creditCardDetection.transactionCount).toBe(10);
       expect(updatedUser.onboarding.creditCardDetection.recommendation).toBe('connect');
+      expect(updatedUser.onboarding.creditCardDetection.suggestedProviders).toEqual([
+        expect.objectContaining({ bankId: 'isracard', paymentCount: 2 })
+      ]);
       
       // Verify current step - always shows detection UI first
       expect(updatedUser.onboarding.currentStep).toBe('credit-card-detection');

--- a/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
+++ b/backend/src/onboarding/services/onboardingCreditCardDetectionService.js
@@ -41,6 +41,7 @@ class OnboardingCreditCardDetectionService {
           'onboarding.creditCardDetection.transactionCount': analysis.transactionCount,
           'onboarding.creditCardDetection.recommendation': analysis.recommendation,
           'onboarding.creditCardDetection.sampleTransactions': analysis.sampleTransactions.slice(0, 5),
+          'onboarding.creditCardDetection.suggestedProviders': analysis.suggestedProviders || [],
           'onboarding.currentStep': 'credit-card-detection'
         }
       },

--- a/frontend/src/components/onboarding/chat/__tests__/providerSuggestions.test.ts
+++ b/frontend/src/components/onboarding/chat/__tests__/providerSuggestions.test.ts
@@ -1,0 +1,21 @@
+import { providerSuggestionsFor } from '../providerSuggestions';
+import { OnboardingStatus } from '../../../../services/api/onboarding';
+
+describe('providerSuggestionsFor', () => {
+  it('recognizes supported providers from English settlement descriptions', () => {
+    const detection = {
+      sampleTransactions: [
+        { date: '2026-08-01', description: 'Isracard monthly payment', amount: 1000 },
+        { date: '2026-08-01', description: 'Diners Club monthly payment', amount: 2000 },
+        { date: '2026-08-01', description: 'CAL monthly payment', amount: 3000 },
+        { date: '2026-08-01', description: 'MAX monthly payment', amount: 4000 }
+      ]
+    } as OnboardingStatus['creditCardDetection'];
+
+    expect(providerSuggestionsFor(detection)).toEqual([
+      { bankId: 'visaCal', name: 'Visa Cal', paymentCount: 2 },
+      { bankId: 'isracard', name: 'Isracard', paymentCount: 1 },
+      { bankId: 'max', name: 'Max', paymentCount: 1 }
+    ]);
+  });
+});

--- a/frontend/src/components/onboarding/chat/__tests__/providerSuggestions.test.ts
+++ b/frontend/src/components/onboarding/chat/__tests__/providerSuggestions.test.ts
@@ -4,18 +4,43 @@ import { OnboardingStatus } from '../../../../services/api/onboarding';
 describe('providerSuggestionsFor', () => {
   it('recognizes supported providers from English settlement descriptions', () => {
     const detection = {
+      analyzed: true,
+      analyzedAt: '2026-08-10T20:00:00Z',
+      transactionCount: 4,
+      recommendation: 'connect',
       sampleTransactions: [
         { date: '2026-08-01', description: 'Isracard monthly payment', amount: 1000 },
         { date: '2026-08-01', description: 'Diners Club monthly payment', amount: 2000 },
         { date: '2026-08-01', description: 'CAL monthly payment', amount: 3000 },
         { date: '2026-08-01', description: 'MAX monthly payment', amount: 4000 }
       ]
-    } as OnboardingStatus['creditCardDetection'];
+    } satisfies OnboardingStatus['creditCardDetection'];
 
     expect(providerSuggestionsFor(detection)).toEqual([
       { bankId: 'visaCal', name: 'Visa Cal', paymentCount: 2 },
       { bankId: 'isracard', name: 'Isracard', paymentCount: 1 },
       { bankId: 'max', name: 'Max', paymentCount: 1 }
+    ]);
+  });
+
+  it('uses the backend provider order to break stored-suggestion ties', () => {
+    const detection = {
+      analyzed: true,
+      analyzedAt: '2026-08-10T20:00:00Z',
+      transactionCount: 6,
+      recommendation: 'connect',
+      suggestedProviders: [
+        { bankId: 'max', paymentCount: 2 },
+        { bankId: 'isracard', paymentCount: 2 },
+        { bankId: 'visaCal', paymentCount: 2 }
+      ],
+      sampleTransactions: []
+    } satisfies OnboardingStatus['creditCardDetection'];
+
+    expect(providerSuggestionsFor(detection).map(({ bankId }) => bankId)).toEqual([
+      'isracard',
+      'visaCal',
+      'max'
     ]);
   });
 });

--- a/frontend/src/components/onboarding/chat/__tests__/script.test.ts
+++ b/frontend/src/components/onboarding/chat/__tests__/script.test.ts
@@ -150,12 +150,14 @@ describe('buildScript', () => {
           analyzedAt: '2026-01-01T00:06:00Z',
           transactionCount: 47,
           recommendation: 'connect',
-          sampleTransactions: []
+          sampleTransactions: [],
+          suggestedProviders: [{ bankId: 'isracard', paymentCount: 12 }]
         }
       })
     );
 
     expect(textOf(script)).toContain('47 credit card payments');
+    expect(textOf(script)).toContain('descriptions suggest Isracard');
     expect(cardsOf(script)).toEqual(['credit-card-choice']);
   });
 

--- a/frontend/src/components/onboarding/chat/cards/CreditCardChoiceCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CreditCardChoiceCard.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Typography, Stack, Divider } from '@mui/material';
 import { CreditCard as CreditCardIcon } from '@mui/icons-material';
 import { CardShell } from '../CardShell';
 import { CardProps } from '../types';
+import { providerNames, providerSuggestionsFor } from '../providerSuggestions';
 
 /**
  * A branch in the conversation. Both options are phrased as something the user
@@ -10,7 +11,10 @@ import { CardProps } from '../types';
  */
 export const CreditCardChoiceCard: React.FC<CardProps> = ({ status, handlers }) => {
   const [busy, setBusy] = useState<'connect' | 'skip' | null>(null);
-  const samples = status.creditCardDetection?.sampleTransactions || [];
+  const detection = status.creditCardDetection;
+  const samples = detection?.sampleTransactions || [];
+  const hiddenPaymentCount = Math.max(0, (detection?.transactionCount || 0) - samples.length);
+  const providerSuggestions = providerSuggestionsFor(detection);
 
   const choose = async (choice: 'connect' | 'skip') => {
     setBusy(choice);
@@ -29,7 +33,7 @@ export const CreditCardChoiceCard: React.FC<CardProps> = ({ status, handlers }) 
             Payments I spotted
           </Typography>
           <Stack spacing={0.5} sx={{ mt: 1, mb: 2 }}>
-            {samples.slice(0, 3).map((transaction, index) => (
+            {samples.map((transaction, index) => (
               <Box key={index} sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
                 <Typography variant="body2" noWrap sx={{ flex: 1 }}>
                   {transaction.description}
@@ -39,10 +43,27 @@ export const CreditCardChoiceCard: React.FC<CardProps> = ({ status, handlers }) 
                 </Typography>
               </Box>
             ))}
+            {hiddenPaymentCount > 0 && (
+              <Typography variant="caption" color="text.secondary">
+                +{hiddenPaymentCount.toLocaleString()} more
+              </Typography>
+            )}
           </Stack>
-          <Divider sx={{ mb: 2 }} />
         </>
       )}
+
+      {providerSuggestions.length > 0 && (
+        <Box sx={{ p: 1.5, mb: 2, borderRadius: 2, bgcolor: 'action.hover' }}>
+          <Typography variant="caption" color="text.secondary">
+            Suggested provider{providerSuggestions.length === 1 ? '' : 's'}
+          </Typography>
+          <Typography variant="body2" fontWeight={600}>
+            {providerNames(providerSuggestions)}
+          </Typography>
+        </Box>
+      )}
+
+      {(samples.length > 0 || providerSuggestions.length > 0) && <Divider sx={{ mb: 2 }} />}
 
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
         <Button

--- a/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   TextField,
@@ -25,6 +25,13 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
   const [loading, setLoading] = useState(false);
   const [skipping, setSkipping] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!suggestedProvider?.bankId) return;
+    setForm((previous) =>
+      previous.bankId ? previous : { ...previous, bankId: suggestedProvider.bankId }
+    );
+  }, [suggestedProvider?.bankId]);
 
   const handleText = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;

--- a/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
@@ -13,9 +13,15 @@ import { CREDIT_CARD_PROVIDERS } from '../../../../constants/banks';
 import { BankPicker } from '../../../bank/BankPicker';
 import { CardShell } from '../CardShell';
 import { CardProps } from '../types';
+import { providerSuggestionsFor } from '../providerSuggestions';
 
-export const CreditCardFormCard: React.FC<CardProps> = ({ handlers }) => {
-  const [form, setForm] = useState({ bankId: '', username: '', password: '' });
+export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) => {
+  const suggestedProvider = providerSuggestionsFor(status.creditCardDetection)[0];
+  const [form, setForm] = useState({
+    bankId: suggestedProvider?.bankId || '',
+    username: '',
+    password: ''
+  });
   const [loading, setLoading] = useState(false);
   const [skipping, setSkipping] = useState(false);
   const [error, setError] = useState('');
@@ -76,7 +82,11 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ handlers }) => {
           value={form.bankId}
           onChange={handleProvider}
           label="Card provider"
-          helperText="Whoever issues the card, which is not always the bank you just connected."
+          helperText={
+            suggestedProvider
+              ? `${suggestedProvider.name} was suggested from your bank statement. Choose another if needed.`
+              : 'Whoever issues the card, which is not always the bank you just connected.'
+          }
           testId="provider-select"
         />
 

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardChoiceCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardChoiceCard.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CreditCardChoiceCard } from '../CreditCardChoiceCard';
+import { OnboardingStatus } from '../../../../../services/api/onboarding';
+import { ChatHandlers } from '../../types';
+
+const handlers: ChatHandlers = {
+  connectCheckingAccount: jest.fn().mockResolvedValue(undefined),
+  connectCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  proceedToCreditCardSetup: jest.fn().mockResolvedValue(undefined),
+  skipCreditCards: jest.fn().mockResolvedValue(undefined),
+  completeOnboarding: jest.fn().mockResolvedValue(undefined)
+};
+
+const status = {
+  creditCardDetection: {
+    analyzed: true,
+    analyzedAt: '2026-08-10T20:00:00Z',
+    transactionCount: 5,
+    recommendation: 'connect',
+    sampleTransactions: [
+      { date: '2026-08-01', description: 'ישראכרט בע"מ-י', amount: 557 },
+      { date: '2026-07-01', description: 'כרטיסי אשראי-י', amount: 10009.46 },
+      { date: '2026-06-01', description: 'כרטיסי אשראי-י 2', amount: 37964.51 },
+      { date: '2026-05-01', description: 'כרטיסי אשראי-י 3', amount: 2000 },
+      { date: '2026-04-01', description: 'כרטיסי אשראי-י 4', amount: 3000 }
+    ]
+  }
+} as OnboardingStatus;
+
+describe('CreditCardChoiceCard', () => {
+  it('shows every payment sample returned by detection', () => {
+    render(<CreditCardChoiceCard status={status} handlers={handlers} />);
+
+    for (const transaction of status.creditCardDetection.sampleTransactions) {
+      expect(screen.getByText(transaction.description)).toBeInTheDocument();
+    }
+  });
+
+  it('suggests a provider from existing sample descriptions', () => {
+    render(<CreditCardChoiceCard status={status} handlers={handlers} />);
+
+    expect(screen.getByText('Suggested provider')).toBeInTheDocument();
+    expect(screen.getByText('Isracard')).toBeInTheDocument();
+  });
+
+  it('explains when detection found more payments than the saved sample', () => {
+    render(
+      <CreditCardChoiceCard
+        status={{
+          ...status,
+          creditCardDetection: {
+            ...status.creditCardDetection,
+            transactionCount: 7
+          }
+        }}
+        handlers={handlers}
+      />
+    );
+
+    expect(screen.getByText('+2 more')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
@@ -79,6 +79,48 @@ describe('CreditCardFormCard provider selection', () => {
     expect(within(group).getByRole('radio', { name: 'Isracard' })).toBeChecked();
     expect(screen.getByText(/isracard was suggested from your bank statement/i)).toBeInTheDocument();
   });
+
+  it('applies a suggestion that arrives after the form first renders', async () => {
+    const { rerender } = render(
+      <CreditCardFormCard status={{} as OnboardingStatus} handlers={handlers} />
+    );
+
+    rerender(
+      <CreditCardFormCard
+        status={{
+          creditCardDetection: {
+            suggestedProviders: [{ bankId: 'isracard', paymentCount: 3 }]
+          }
+        } as OnboardingStatus}
+        handlers={handlers}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('radio', { name: 'Isracard' })).toBeChecked()
+    );
+  });
+
+  it('does not replace a provider the user already selected', async () => {
+    const { rerender } = render(
+      <CreditCardFormCard status={{} as OnboardingStatus} handlers={handlers} />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Max' }));
+
+    rerender(
+      <CreditCardFormCard
+        status={{
+          creditCardDetection: {
+            suggestedProviders: [{ bankId: 'isracard', paymentCount: 3 }]
+          }
+        } as OnboardingStatus}
+        handlers={handlers}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'Max' })).toBeChecked());
+    expect(screen.getByRole('radio', { name: 'Isracard' })).not.toBeChecked();
+  });
 });
 
 describe('CreditCardFormCard submission', () => {

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
@@ -13,8 +13,8 @@ const handlers: ChatHandlers = {
   completeOnboarding: jest.fn().mockResolvedValue(undefined)
 };
 
-const showCard = () => {
-  render(<CreditCardFormCard status={{} as OnboardingStatus} handlers={handlers} />);
+const showCard = (status = {} as OnboardingStatus) => {
+  render(<CreditCardFormCard status={status} handlers={handlers} />);
   return screen.getByTestId('provider-select');
 };
 
@@ -67,6 +67,17 @@ describe('CreditCardFormCard provider selection', () => {
     for (const provider of CREDIT_CARD_PROVIDERS) {
       expect(within(group).getByRole('radio', { name: provider.name })).toBeInTheDocument();
     }
+  });
+
+  it('preselects the strongest detected provider suggestion', () => {
+    const group = showCard({
+      creditCardDetection: {
+        suggestedProviders: [{ bankId: 'isracard', paymentCount: 3 }]
+      }
+    } as OnboardingStatus);
+
+    expect(within(group).getByRole('radio', { name: 'Isracard' })).toBeChecked();
+    expect(screen.getByText(/isracard was suggested from your bank statement/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/onboarding/chat/providerSuggestions.ts
+++ b/frontend/src/components/onboarding/chat/providerSuggestions.ts
@@ -1,0 +1,56 @@
+import { CREDIT_CARD_PROVIDERS } from '../../../constants/banks';
+import { OnboardingStatus } from '../../../services/api/onboarding';
+
+const PROVIDER_HINTS = [
+  { bankId: 'isracard', pattern: /ישראכרט|\bisracard\b/i },
+  { bankId: 'visaCal', pattern: /דיינרס|ויזה\s*כאל|^\s*כאל(?:\s*-\s*י)?\s*$|\bdiners(?:\s+club)?\b|\bvisa\s*cal\b|\bcal\s+monthly\s+payment\b/i },
+  { bankId: 'max', pattern: /מקס\s*(?:איט\s*)?פיננסים|^\s*מקס(?:\s*-\s*י)?\s*$|\bmax\s+monthly\s+payment\b/i }
+];
+
+export interface ProviderSuggestion {
+  bankId: string;
+  name: string;
+  paymentCount: number;
+}
+
+const providerName = (bankId: string): string | null =>
+  CREDIT_CARD_PROVIDERS.find((provider) => provider.id === bankId)?.name || null;
+
+export const providerSuggestionsFor = (
+  detection?: OnboardingStatus['creditCardDetection'] | null
+): ProviderSuggestion[] => {
+  const storedSuggestions = detection?.suggestedProviders || [];
+  if (storedSuggestions.length > 0) {
+    return storedSuggestions
+      .map((suggestion) => {
+        const name = providerName(suggestion.bankId);
+        return name ? { ...suggestion, name } : null;
+      })
+      .filter((suggestion): suggestion is ProviderSuggestion => suggestion !== null)
+      .sort((left, right) => right.paymentCount - left.paymentCount);
+  }
+
+  const counts = new Map<string, number>();
+  for (const transaction of detection?.sampleTransactions || []) {
+    const hint = PROVIDER_HINTS.find(({ pattern }) => pattern.test(transaction.description));
+    if (hint) counts.set(hint.bankId, (counts.get(hint.bankId) || 0) + 1);
+  }
+
+  return PROVIDER_HINTS
+    .map(({ bankId }) => ({
+      bankId,
+      name: providerName(bankId),
+      paymentCount: counts.get(bankId) || 0
+    }))
+    .filter(
+      (suggestion): suggestion is ProviderSuggestion =>
+        suggestion.name !== null && suggestion.paymentCount > 0
+    )
+    .sort((left, right) => right.paymentCount - left.paymentCount);
+};
+
+export const providerNames = (suggestions: ProviderSuggestion[]): string => {
+  const names = suggestions.map((suggestion) => suggestion.name);
+  if (names.length <= 1) return names[0] || '';
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+};

--- a/frontend/src/components/onboarding/chat/providerSuggestions.ts
+++ b/frontend/src/components/onboarding/chat/providerSuggestions.ts
@@ -1,11 +1,18 @@
 import { CREDIT_CARD_PROVIDERS } from '../../../constants/banks';
 import { OnboardingStatus } from '../../../services/api/onboarding';
 
+// Keep these legacy-record fallback patterns aligned with
+// backend/src/banking/services/creditCardPaymentMatcher.js. New analyses carry
+// server-generated suggestions; this path exists for onboarding records saved
+// before that field was introduced.
 const PROVIDER_HINTS = [
   { bankId: 'isracard', pattern: /ישראכרט|\bisracard\b/i },
   { bankId: 'visaCal', pattern: /דיינרס|ויזה\s*כאל|^\s*כאל(?:\s*-\s*י)?\s*$|\bdiners(?:\s+club)?\b|\bvisa\s*cal\b|\bcal\s+monthly\s+payment\b/i },
   { bankId: 'max', pattern: /מקס\s*(?:איט\s*)?פיננסים|^\s*מקס(?:\s*-\s*י)?\s*$|\bmax\s+monthly\s+payment\b/i }
 ];
+const PROVIDER_ORDER = new Map(
+  PROVIDER_HINTS.map((provider, index) => [provider.bankId, index])
+);
 
 export interface ProviderSuggestion {
   bankId: string;
@@ -27,7 +34,10 @@ export const providerSuggestionsFor = (
         return name ? { ...suggestion, name } : null;
       })
       .filter((suggestion): suggestion is ProviderSuggestion => suggestion !== null)
-      .sort((left, right) => right.paymentCount - left.paymentCount);
+      .sort((left, right) =>
+        right.paymentCount - left.paymentCount ||
+        (PROVIDER_ORDER.get(left.bankId) || 0) - (PROVIDER_ORDER.get(right.bankId) || 0)
+      );
   }
 
   const counts = new Map<string, number>();
@@ -46,7 +56,10 @@ export const providerSuggestionsFor = (
       (suggestion): suggestion is ProviderSuggestion =>
         suggestion.name !== null && suggestion.paymentCount > 0
     )
-    .sort((left, right) => right.paymentCount - left.paymentCount);
+    .sort((left, right) =>
+      right.paymentCount - left.paymentCount ||
+      (PROVIDER_ORDER.get(left.bankId) || 0) - (PROVIDER_ORDER.get(right.bankId) || 0)
+    );
 };
 
 export const providerNames = (suggestions: ProviderSuggestion[]): string => {

--- a/frontend/src/components/onboarding/chat/script.ts
+++ b/frontend/src/components/onboarding/chat/script.ts
@@ -1,5 +1,6 @@
 import { OnboardingStatus } from '../../../services/api/onboarding';
 import { CHECKING_ACCOUNT_BANKS, CREDIT_CARD_PROVIDERS } from '../../../constants/banks';
+import { providerNames, providerSuggestionsFor } from './providerSuggestions';
 import { CardId, ChatMessage, Script } from './types';
 
 /**
@@ -123,9 +124,13 @@ const describeImport = (count: number): string => {
 const describeDetection = (detection: OnboardingStatus['creditCardDetection']): string => {
   const count = detection.transactionCount || 0;
   const payments = `${count} credit card payment${count === 1 ? '' : 's'}`;
+  const suggestedProviderNames = providerNames(providerSuggestionsFor(detection));
+  const providerHint = suggestedProviderNames
+    ? ` The payment descriptions suggest ${suggestedProviderNames}.`
+    : '';
 
   if (detection.recommendation === 'connect') {
-    return `I found ${payments} in there. Those are the monthly bills - what you actually spent is only on the card statement. Connect your card provider and I can see that too.`;
+    return `I found ${payments} in there.${providerHint} Those are the monthly bills - what you actually spent is only on the card statement. Connect your card provider and I can see that too.`;
   }
   if (count > 0) {
     return `I only found ${payments}, so cards look optional for you. You can still connect one, or skip and add it later.`;

--- a/frontend/src/services/api/onboarding.ts
+++ b/frontend/src/services/api/onboarding.ts
@@ -41,6 +41,10 @@ export interface OnboardingStatus {
       description: string;
       amount: number;
     }>;
+    suggestedProviders?: Array<{
+      bankId: string;
+      paymentCount: number;
+    }>;
   };
   
   creditCardSetup: {


### PR DESCRIPTION
## What Changed
- Show every saved credit-card payment sample in onboarding instead of truncating the list to three, with a remaining-count label when detection found more than the five saved samples.
- Infer Isracard, Visa Cal, and Max from Hebrew and English settlement descriptions; Diners is mapped to Visa Cal.
- Persist provider suggestions for new analyses and derive them client-side from saved samples for existing onboarding records.
- Mention the likely provider in the conversation and preselect the strongest suggestion in the provider picker.

## Why
Onboarding correctly detected five card payments but displayed only three, which made the result look inconsistent. The imported settlement labels already contain enough issuer information to remove an unnecessary provider-selection step for many users.

## Impact Analysis
- Existing onboarding data works without migration because the frontend falls back to the stored payment samples.
- Provider matching is limited to supported issuers and conservative settlement-shaped labels.
- No dependency, credential, or configuration changes.

## Quality Gates
- Added backend coverage for Hebrew and English provider inference and persistence.
- Added frontend coverage for displaying all samples, remaining-count messaging, legacy fallback inference, conversation copy, and provider preselection.
- Backend and frontend repository gates pass.

## Deployment Considerations
No migration or configuration changes are required. Both API and frontend should deploy together so future analyses persist suggestions while existing sessions receive the UI fallback.