### PR TITLE
bugfix(banking): support Isracard card suffix login

### DIFF
--- a/backend/src/banking/__tests__/BankAccount.test.js
+++ b/backend/src/banking/__tests__/BankAccount.test.js
@@ -138,6 +138,27 @@ describe('BankAccount Model', () => {
       });
     });
 
+    it('should map and decrypt Isracard credentials for the scraper', async () => {
+      const account = await BankAccount.create({
+        ...mockAccount,
+        bankId: 'isracard',
+        credentials: {
+          username: validCredentials.username,
+          password: validCredentials.password,
+          card6Digits: validCredentials.card6Digits
+        }
+      });
+
+      const savedAccount = await BankAccount.findById(account._id);
+      expect(savedAccount.credentials.card6Digits).not.toBe(validCredentials.card6Digits);
+      expect(credentialEncryption.isEncrypted(savedAccount.credentials.card6Digits)).toBe(true);
+      expect((await savedAccount.getScraperOptions()).credentials).toEqual({
+        id: validCredentials.username,
+        card6Digits: validCredentials.card6Digits,
+        password: validCredentials.password
+      });
+    });
+
     it('should default first-time scraping to the past year', async () => {
       const before = new Date();
       before.setMonth(before.getMonth() - 12);
@@ -175,6 +196,7 @@ describe('BankAccount Model', () => {
       expect(json.credentials).toBeDefined();
       expect(json.credentials.username).toBe(mockAccount.credentials.username);
       expect(json.credentials.password).toBeUndefined();
+      expect(json.credentials.card6Digits).toBeUndefined();
       expect(json.bankId).toBe(mockAccount.bankId);
       expect(json.name).toBe(mockAccount.name);
     });

--- a/backend/src/banking/models/BankAccount.js
+++ b/backend/src/banking/models/BankAccount.js
@@ -3,6 +3,10 @@ const credentialEncryption = require('../../shared/services/credentialEncryption
 const { resolveStartDate, DEFAULT_LOOKBACK_MONTHS } = require('../utils/scraperDates');
 const logger = require('../../shared/utils/logger');
 const { OTP_BANKS } = require('../constants/enums');
+const {
+  ISRACARD_BANK_ID,
+  buildScraperCredentials
+} = require('../utils/scraperCredentials');
 
 const bankAccountSchema = new mongoose.Schema({
   userId: {
@@ -32,6 +36,9 @@ const bankAccountSchema = new mongoose.Schema({
     password: {
       type: String,
       required: function() { return this.bankId !== 'mercury' && this.bankId !== 'ibkr' && !OTP_BANKS.includes(this.bankId); }
+    },
+    card6Digits: {
+      type: String
     },
     apiToken: {
       type: String,
@@ -218,7 +225,7 @@ const isEncrypted = credentialEncryption.isEncrypted;
 // Pre-save middleware to encrypt credentials with this user's own key
 bankAccountSchema.pre('save', async function(next) {
   try {
-    const fields = ['password', 'apiToken', 'flexToken', 'phoneOrEmail'];
+    const fields = ['password', 'card6Digits', 'apiToken', 'flexToken', 'phoneOrEmail'];
     for (const field of fields) {
       const value = this.credentials?.[field];
       if (this.isModified(`credentials.${field}`) && value && !isEncrypted(value)) {
@@ -241,14 +248,26 @@ bankAccountSchema.methods.getDefaultStartDate = function() {
   return resolveStartDate(this.lastScraped);
 };
 
+bankAccountSchema.methods.getScraperCredentials = async function() {
+  const credentials = {
+    username: this.credentials.username,
+    password: await credentialEncryption.decryptForUser(this.userId, this.credentials.password)
+  };
+
+  if (this.bankId === ISRACARD_BANK_ID) {
+    credentials.card6Digits = this.credentials.card6Digits
+      ? await credentialEncryption.decryptForUser(this.userId, this.credentials.card6Digits)
+      : undefined;
+  }
+
+  return buildScraperCredentials(this.bankId, credentials);
+};
+
 // Method to get scraper options for a specific strategy
 bankAccountSchema.methods.getScraperOptionsForStrategy = async function(strategyName) {
   const options = {
     companyId: this.bankId,
-    credentials: {
-      username: this.credentials.username,
-      password: await credentialEncryption.decryptForUser(this.userId, this.credentials.password)
-    },
+    credentials: await this.getScraperCredentials(),
     startDate: this.getStartDateForStrategy(strategyName),
     showBrowser: false,
     verbose: false
@@ -261,10 +280,7 @@ bankAccountSchema.methods.getScraperOptionsForStrategy = async function(strategy
 bankAccountSchema.methods.getScraperOptions = async function() {
   const options = {
     companyId: this.bankId,
-    credentials: {
-      username: this.credentials.username,
-      password: await credentialEncryption.decryptForUser(this.userId, this.credentials.password)
-    },
+    credentials: await this.getScraperCredentials(),
     startDate: this.getDefaultStartDate(),
     showBrowser: false,
     verbose: false

--- a/backend/src/banking/routes/__tests__/bankAccounts.test.js
+++ b/backend/src/banking/routes/__tests__/bankAccounts.test.js
@@ -76,6 +76,75 @@ describe('Bank Account Routes', () => {
       expect(response.status).toBe(400);
       expect(response.body).toHaveProperty('error', 'Missing required fields');
     });
+
+    it('should require exactly six card digits for Isracard', async () => {
+      const response = await request(app)
+        .post('/api/bank-accounts')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          bankId: 'isracard',
+          name: 'My Isracard',
+          credentials: {
+            username: validCredentials.username,
+            password: validCredentials.password,
+            card6Digits: '12345'
+          }
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Last 6 card digits must be exactly 6 digits');
+    });
+  });
+
+  describe('PUT /api/bank-accounts/:id/credentials', () => {
+    let isracardAccount;
+
+    beforeEach(async () => {
+      isracardAccount = await BankAccount.create({
+        userId: user._id,
+        bankId: 'isracard',
+        name: 'My Isracard',
+        credentials: {
+          username: validCredentials.username,
+          password: validCredentials.password
+        },
+        status: 'error'
+      });
+    });
+
+    it('should require exactly six card digits when updating Isracard', async () => {
+      const response = await request(app)
+        .put(`/api/bank-accounts/${isracardAccount._id}/credentials`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          username: validCredentials.username,
+          password: validCredentials.password,
+          card6Digits: '12345'
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Last 6 card digits must be exactly 6 digits');
+    });
+
+    it('should save Isracard credentials in the scraper-required shape', async () => {
+      const response = await request(app)
+        .put(`/api/bank-accounts/${isracardAccount._id}/credentials`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          username: validCredentials.username,
+          password: validCredentials.password,
+          card6Digits: validCredentials.card6Digits
+        });
+
+      expect(response.status).toBe(200);
+      const updatedAccount = await BankAccount.findById(isracardAccount._id);
+      expect(updatedAccount.status).toBe('active');
+      expect((await updatedAccount.getScraperOptions()).credentials).toEqual({
+        id: validCredentials.username,
+        card6Digits: validCredentials.card6Digits,
+        password: validCredentials.password
+      });
+    });
   });
 
   describe('POST /api/bank-accounts/scrape-all', () => {

--- a/backend/src/banking/routes/__tests__/bankAccounts.test.js
+++ b/backend/src/banking/routes/__tests__/bankAccounts.test.js
@@ -8,6 +8,7 @@ const queuedDataSyncService = require('../../services/queuedDataSyncService');
 const app = require('../../../app');
 const { User } = require('../../../auth');
 const { BankAccount } = require('../../models');
+const credentialEncryption = require('../../../shared/services/credentialEncryption');
 
 // Import valid credentials from mock (bankScraperService handles the mocking automatically based on NODE_ENV)
 const { validCredentials } = require('../../../test/mocks/bankScraper');
@@ -144,6 +145,38 @@ describe('Bank Account Routes', () => {
         card6Digits: validCredentials.card6Digits,
         password: validCredentials.password
       });
+    });
+
+    it('should update IBKR Flex credentials instead of treating it as Mercury', async () => {
+      const ibkrAccount = await BankAccount.create({
+        userId: user._id,
+        bankId: 'ibkr',
+        name: 'Interactive Brokers',
+        credentials: {
+          flexToken: 'old-flex-token',
+          queryId: '111'
+        },
+        status: 'error'
+      });
+
+      const response = await request(app)
+        .put(`/api/bank-accounts/${ibkrAccount._id}/credentials`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          flexToken: 'new-flex-token',
+          queryId: '222'
+        });
+
+      expect(response.status).toBe(200);
+      const updatedAccount = await BankAccount.findById(ibkrAccount._id);
+      expect(updatedAccount.status).toBe('active');
+      expect(updatedAccount.credentials.queryId).toBe('222');
+      expect(
+        await credentialEncryption.decryptForUser(
+          updatedAccount.userId,
+          updatedAccount.credentials.flexToken
+        )
+      ).toBe('new-flex-token');
     });
   });
 

--- a/backend/src/banking/routes/bankAccounts.js
+++ b/backend/src/banking/routes/bankAccounts.js
@@ -3,6 +3,10 @@ const BankAccount = require('../models/BankAccount');
 const auth = require('../../shared/middleware/auth');
 const bankAccountService = require('../services/bankAccountService.js');
 const { OTP_BANKS } = require('../constants/enums');
+const {
+  ISRACARD_BANK_ID,
+  isValidCard6Digits
+} = require('../utils/scraperCredentials');
 
 const router = express.Router();
 
@@ -37,6 +41,9 @@ router.post('/', auth, async (req, res) => {
       if (!bankId || !name || !credentials?.username || !credentials?.password) {
         return res.status(400).json({ error: 'Missing required fields' });
       }
+      if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(credentials.card6Digits)) {
+        return res.status(400).json({ error: 'Last 6 card digits must be exactly 6 digits' });
+      }
     }
 
     const bankAccount = await bankAccountService.create(req.user._id, {
@@ -44,6 +51,7 @@ router.post('/', auth, async (req, res) => {
       name,
       username: credentials.username,
       password: credentials.password,
+      card6Digits: credentials.card6Digits,
       apiToken: credentials.apiToken,
       flexToken: credentials.flexToken,
       queryId: credentials.queryId,
@@ -71,7 +79,7 @@ router.patch('/:id', auth, async (req, res) => {
 // Update bank account credentials
 router.put('/:id/credentials', auth, async (req, res) => {
   try {
-    const { username, password, apiToken } = req.body;
+    const { username, password, card6Digits, apiToken } = req.body;
 
     // Look up account to determine bank type
     const account = await BankAccount.findOne({ _id: req.params.id, userId: req.user._id });
@@ -87,12 +95,15 @@ router.put('/:id/credentials', auth, async (req, res) => {
       if (!username || !password) {
         return res.status(400).json({ error: 'Username and password are required' });
       }
+      if (account.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+        return res.status(400).json({ error: 'Last 6 card digits must be exactly 6 digits' });
+      }
     }
 
     const bankAccount = await bankAccountService.updateCredentials(
       req.params.id,
       req.user._id,
-      { username, password, apiToken }
+      { username, password, card6Digits, apiToken }
     );
 
     res.json({

--- a/backend/src/banking/routes/bankAccounts.js
+++ b/backend/src/banking/routes/bankAccounts.js
@@ -79,7 +79,7 @@ router.patch('/:id', auth, async (req, res) => {
 // Update bank account credentials
 router.put('/:id/credentials', auth, async (req, res) => {
   try {
-    const { username, password, card6Digits, apiToken } = req.body;
+    const { username, password, card6Digits, apiToken, flexToken, queryId } = req.body;
 
     // Look up account to determine bank type
     const account = await BankAccount.findOne({ _id: req.params.id, userId: req.user._id });
@@ -90,6 +90,10 @@ router.put('/:id/credentials', auth, async (req, res) => {
     if (account.bankId === 'mercury') {
       if (!apiToken) {
         return res.status(400).json({ error: 'API token is required for Mercury' });
+      }
+    } else if (account.bankId === 'ibkr') {
+      if (!flexToken || !queryId) {
+        return res.status(400).json({ error: 'Flex token and Query ID are required for Interactive Brokers' });
       }
     } else {
       if (!username || !password) {
@@ -103,7 +107,7 @@ router.put('/:id/credentials', auth, async (req, res) => {
     const bankAccount = await bankAccountService.updateCredentials(
       req.params.id,
       req.user._id,
-      { username, password, card6Digits, apiToken }
+      { username, password, card6Digits, apiToken, flexToken, queryId }
     );
 
     res.json({

--- a/backend/src/banking/services/__tests__/bankAccountService.test.js
+++ b/backend/src/banking/services/__tests__/bankAccountService.test.js
@@ -102,6 +102,37 @@ describe('BankAccountService', () => {
       // Verify no event was emitted
       expect(eventListeners.accountCreated).not.toHaveBeenCalled();
     });
+
+    it('should validate and store Isracard last-six credentials', async () => {
+      bankScraperService.validateCredentials.mockResolvedValueOnce(true);
+
+      const account = await bankAccountService.create(userId, {
+        ...mockAccountData,
+        bankId: 'isracard',
+        card6Digits: validCredentials.card6Digits
+      });
+
+      expect(bankScraperService.validateCredentials).toHaveBeenCalledWith('isracard', {
+        id: validCredentials.username,
+        card6Digits: validCredentials.card6Digits,
+        password: validCredentials.password
+      });
+      expect((await account.getScraperOptions()).credentials).toEqual({
+        id: validCredentials.username,
+        card6Digits: validCredentials.card6Digits,
+        password: validCredentials.password
+      });
+    });
+
+    it('should reject Isracard credentials without exactly six card digits', async () => {
+      await expect(bankAccountService.create(userId, {
+        ...mockAccountData,
+        bankId: 'isracard',
+        card6Digits: '12345'
+      })).rejects.toThrow('Last 6 card digits must be exactly 6 digits');
+
+      expect(bankScraperService.validateCredentials).not.toHaveBeenCalled();
+    });
   });
 
   describe('delete', () => {

--- a/backend/src/banking/services/__tests__/bankScraperService.test.js
+++ b/backend/src/banking/services/__tests__/bankScraperService.test.js
@@ -89,6 +89,16 @@ describe('BankScraperService', () => {
         password: 'invalid'
       })).rejects.toThrow('Login failed: Invalid bank credentials');
     });
+
+    it('should preserve Isracard-specific credential fields', async () => {
+      const result = await bankScraperService.validateCredentials('isracard', {
+        id: 'testuser',
+        card6Digits: '123456',
+        password: 'bankpass123'
+      });
+
+      expect(result).toBe(true);
+    });
   });
 
   describe('testConnection', () => {

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -119,7 +119,14 @@ class BankAccountService {
     }
   }
 
-  async updateCredentials(accountId, userId, { username, password, card6Digits, apiToken }) {
+  async updateCredentials(accountId, userId, {
+    username,
+    password,
+    card6Digits,
+    apiToken,
+    flexToken,
+    queryId
+  }) {
     const bankAccount = await BankAccount.findOne({ _id: accountId, userId });
     if (!bankAccount) {
       throw new Error('Bank account not found');
@@ -128,6 +135,9 @@ class BankAccountService {
     if (bankAccount.bankId === 'mercury') {
       // Mercury uses API token — no scraper validation
       bankAccount.credentials = { apiToken };
+    } else if (bankAccount.bankId === 'ibkr') {
+      // IBKR uses Flex Web Service token + query ID
+      bankAccount.credentials = { flexToken, queryId };
     } else {
       // Israeli banks: validate new credentials before saving
       if (bankAccount.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -5,9 +5,24 @@ const logger = require('../../shared/utils/logger');
 const bankAccountEvents = require('./bankAccountEvents');
 const ForeignCurrencyAccount = require('../../foreign-currency/models/ForeignCurrencyAccount');
 const { OTP_BANKS } = require('../constants/enums');
+const {
+  ISRACARD_BANK_ID,
+  buildScraperCredentials,
+  isValidCard6Digits
+} = require('../utils/scraperCredentials');
 
 class BankAccountService {
-  async create(userId, { bankId, name, username, password, apiToken, flexToken, queryId, phoneOrEmail }) {
+  async create(userId, {
+    bankId,
+    name,
+    username,
+    password,
+    card6Digits,
+    apiToken,
+    flexToken,
+    queryId,
+    phoneOrEmail
+  }) {
     let credentials;
 
     if (bankId === 'mercury') {
@@ -21,8 +36,18 @@ class BankAccountService {
       credentials = { username, phoneOrEmail };
     } else {
       // Israeli banks use username/password with browser scraping
-      await bankScraperService.validateCredentials(bankId, { username, password });
-      credentials = { username, password };
+      if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+        throw new Error('Last 6 card digits must be exactly 6 digits');
+      }
+      await bankScraperService.validateCredentials(
+        bankId,
+        buildScraperCredentials(bankId, { username, password, card6Digits })
+      );
+      credentials = {
+        username,
+        password,
+        ...(bankId === ISRACARD_BANK_ID && { card6Digits })
+      };
     }
 
     const bankAccount = new BankAccount({
@@ -94,7 +119,7 @@ class BankAccountService {
     }
   }
 
-  async updateCredentials(accountId, userId, { username, password, apiToken }) {
+  async updateCredentials(accountId, userId, { username, password, card6Digits, apiToken }) {
     const bankAccount = await BankAccount.findOne({ _id: accountId, userId });
     if (!bankAccount) {
       throw new Error('Bank account not found');
@@ -105,8 +130,18 @@ class BankAccountService {
       bankAccount.credentials = { apiToken };
     } else {
       // Israeli banks: validate new credentials before saving
-      await bankScraperService.validateCredentials(bankAccount.bankId, { username, password });
-      bankAccount.credentials = { username, password };
+      if (bankAccount.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+        throw new Error('Last 6 card digits must be exactly 6 digits');
+      }
+      await bankScraperService.validateCredentials(
+        bankAccount.bankId,
+        buildScraperCredentials(bankAccount.bankId, { username, password, card6Digits })
+      );
+      bankAccount.credentials = {
+        username,
+        password,
+        ...(bankAccount.bankId === ISRACARD_BANK_ID && { card6Digits })
+      };
     }
 
     // Clear any previous errors

--- a/backend/src/banking/services/bankScraperService.js
+++ b/backend/src/banking/services/bankScraperService.js
@@ -419,7 +419,7 @@ class BankScraperService {
       _id: 'validation',
       lastScraped: null,
       getScraperOptions: () => ({ 
-        credentials: { username: credentials.username, password: credentials.password },
+        credentials,
         startDate: new Date(Date.now() - 180 * 24 * 60 * 60 * 1000) // 6 months back for validation
       })
     };

--- a/backend/src/banking/utils/scraperCredentials.js
+++ b/backend/src/banking/utils/scraperCredentials.js
@@ -1,0 +1,23 @@
+const ISRACARD_BANK_ID = 'isracard';
+const CARD6_DIGITS_PATTERN = /^\d{6}$/;
+
+const isValidCard6Digits = (value) =>
+  typeof value === 'string' && CARD6_DIGITS_PATTERN.test(value);
+
+const buildScraperCredentials = (bankId, { username, password, card6Digits }) => {
+  if (bankId === ISRACARD_BANK_ID) {
+    return {
+      id: username,
+      card6Digits,
+      password
+    };
+  }
+
+  return { username, password };
+};
+
+module.exports = {
+  ISRACARD_BANK_ID,
+  buildScraperCredentials,
+  isValidCard6Digits
+};

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -80,7 +80,8 @@ describe('Onboarding Accounts API', () => {
           bankId: 'hapoalim',
           credentials: {
             username: 'user123',
-            password: 'pass123'
+            password: 'pass123',
+            card6Digits: '123456'
           },
           displayName: 'My Checking'
         });
@@ -178,7 +179,8 @@ describe('Onboarding Accounts API', () => {
           bankId: 'isracard',
           credentials: {
             username: 'user123',
-            password: 'pass123'
+            password: 'pass123',
+            card6Digits: '123456'
           },
           displayName: 'Isracard'
         });
@@ -186,6 +188,10 @@ describe('Onboarding Accounts API', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.onboardingStep).toBe('credit-card-matching');
+      expect(bankAccountService.create).toHaveBeenCalledWith(
+        testUser._id,
+        expect.objectContaining({ card6Digits: '123456' })
+      );
 
       // Verify onboarding structure was updated
       const updatedUser = await User.findById(testUser._id);
@@ -225,7 +231,7 @@ describe('Onboarding Accounts API', () => {
         .set('Authorization', `Bearer ${authToken}`)
         .send({
           bankId: 'isracard',
-          credentials: { username: 'user123', password: 'pass123' }
+          credentials: { username: 'user123', password: 'pass123', card6Digits: '123456' }
         });
 
       // Add second card
@@ -240,6 +246,24 @@ describe('Onboarding Accounts API', () => {
       // Verify both were added
       const updatedUser = await User.findById(testUser._id);
       expect(updatedUser.onboarding.creditCardSetup.creditCardAccounts).toHaveLength(2);
+    });
+
+    it('should reject Isracard without exactly six card digits', async () => {
+      const response = await request(app)
+        .post('/api/onboarding/credit-card-account')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          bankId: 'isracard',
+          credentials: {
+            username: 'user123',
+            password: 'pass123',
+            card6Digits: '12345'
+          }
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Last 6 card digits must be exactly 6 digits');
+      expect(bankAccountService.create).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -5,6 +5,10 @@ const logger = require('../../shared/utils/logger');
 const { User } = require('../../auth');
 const { bankAccountService, Transaction } = require('../../banking');
 const onboardingCreditCardDetectionService = require('../services/onboardingCreditCardDetectionService');
+const {
+  ISRACARD_BANK_ID,
+  isValidCard6Digits
+} = require('../../banking/utils/scraperCredentials');
 
 /**
  * @route   POST /api/onboarding/checking-account
@@ -25,7 +29,6 @@ router.post('/checking-account', auth, async (req, res) => {
         error: 'Bank ID and credentials are required'
       });
     }
-    
     // Create the bank account using the existing service
     const bankAccount = await bankAccountService.create(userId, {
       bankId,
@@ -101,13 +104,26 @@ router.post('/credit-card-account', auth, async (req, res) => {
         error: 'Bank ID and credentials are required'
       });
     }
+    if (!credentials.username || !credentials.password) {
+      return res.status(400).json({
+        success: false,
+        error: 'Username and password are required'
+      });
+    }
+    if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(credentials.card6Digits)) {
+      return res.status(400).json({
+        success: false,
+        error: 'Last 6 card digits must be exactly 6 digits'
+      });
+    }
     
     // Create the bank account using the existing service
     const bankAccount = await bankAccountService.create(userId, {
       bankId,
       name: displayName || bankId,
       username: credentials.username,
-      password: credentials.password
+      password: credentials.password,
+      card6Digits: credentials.card6Digits
     });
     
     // Add to onboarding credit card accounts array

--- a/backend/src/test/mocks/bankScraper.js
+++ b/backend/src/test/mocks/bankScraper.js
@@ -1,6 +1,7 @@
 const validCredentials = {
   username: 'testuser',
-  password: 'bankpass123'
+  password: 'bankpass123',
+  card6Digits: '123456'
 };
 
 // Static date for consistent testing
@@ -46,6 +47,18 @@ const mockTransactions = [
 module.exports = {
   validCredentials,
   createScraper: (options) => {
+    const getUsername = credentials =>
+      options.companyId === 'isracard' ? credentials?.id : credentials?.username;
+    const hasRequiredCredentials = credentials =>
+      Boolean(
+        getUsername(credentials) &&
+        credentials?.password &&
+        (options.companyId !== 'isracard' || /^\d{6}$/.test(credentials?.card6Digits))
+      );
+    const hasValidCredentials = credentials =>
+      getUsername(credentials) === validCredentials.username &&
+      credentials?.password === validCredentials.password &&
+      (options.companyId !== 'isracard' || credentials?.card6Digits === validCredentials.card6Digits);
 
     // Add special case for error testing
     if (options.companyId === 'error_bank') {
@@ -65,9 +78,8 @@ module.exports = {
         return true;
       },
       login: async (credentials) => {
-        
         // For validation and login attempts
-        if (!credentials.username || !credentials.password) {
+        if (!hasRequiredCredentials(credentials)) {
           throw new Error('Missing credentials');
         }
 
@@ -77,7 +89,7 @@ module.exports = {
         
         if (isE2E) {
           // Special case: reject explicitly invalid credentials for error testing
-          if (credentials.username === 'invalid' && credentials.password === 'invalid') {
+          if (getUsername(credentials) === 'invalid' && credentials.password === 'invalid') {
             throw new Error('Invalid bank credentials');
           }
           // Accept all other credentials in e2e mode
@@ -85,8 +97,7 @@ module.exports = {
         }
 
         // In unit test mode, verify against specific test credentials
-        if (credentials.username === validCredentials.username && 
-            credentials.password === validCredentials.password) {
+        if (hasValidCredentials(credentials)) {
           return true;
         }
 
@@ -100,7 +111,7 @@ module.exports = {
         }];
       },
       scrape: async (credentials) => {
-        if (!credentials || !credentials.username || !credentials.password) {
+        if (!hasRequiredCredentials(credentials)) {
           return {
             success: false,
             errorType: 'InvalidCredentials',
@@ -111,8 +122,7 @@ module.exports = {
         const isE2E = process.env.NODE_ENV === 'e2e';
         
         // In e2e mode, accept any credentials and return mock data
-        if (isE2E || (credentials.username === validCredentials.username && 
-            credentials.password === validCredentials.password)) {
+        if (isE2E || hasValidCredentials(credentials)) {
           return {
             success: true,
             accounts: [{

--- a/frontend/src/components/bank/BankAccountForm.tsx
+++ b/frontend/src/components/bank/BankAccountForm.tsx
@@ -40,6 +40,7 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
     name: '',
     username: '',
     password: '',
+    card6Digits: '',
     apiToken: '',
     flexToken: '',
     queryId: '',
@@ -52,7 +53,7 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
     const { name, value } = e.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value
+      [name]: name === 'card6Digits' ? value.replace(/\D/g, '').slice(0, 6) : value
     }));
   };
 
@@ -74,6 +75,12 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
       bankName: SUPPORTED_BANKS.find(bank => bank.id === formData.bankId)?.name
     });
 
+    if (formData.bankId === 'isracard' && !/^\d{6}$/.test(formData.card6Digits)) {
+      setLoading(false);
+      setError('Enter the last 6 digits of your Isracard');
+      return;
+    }
+
     try {
       let credentials;
       if (formData.bankId === 'ibkr') {
@@ -83,7 +90,11 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
       } else if (isApiBank(formData.bankId)) {
         credentials = { apiToken: formData.apiToken };
       } else {
-        credentials = { username: formData.username, password: formData.password };
+        credentials = {
+          username: formData.username,
+          password: formData.password,
+          ...(formData.bankId === 'isracard' && { card6Digits: formData.card6Digits })
+        };
       }
 
       await bankAccountsApi.add({
@@ -121,6 +132,7 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
       name: '',
       username: '',
       password: '',
+      card6Digits: '',
       apiToken: '',
       flexToken: '',
       queryId: '',
@@ -265,12 +277,26 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
               <TextField
                 fullWidth
                 margin="normal"
-                label="Username"
+                label={formData.bankId === 'isracard' ? 'ID Number' : 'Username'}
                 name="username"
                 value={formData.username}
                 onChange={handleInputChange}
                 required
               />
+
+              {formData.bankId === 'isracard' && (
+                <TextField
+                  fullWidth
+                  margin="normal"
+                  label="Last 6 card digits"
+                  name="card6Digits"
+                  value={formData.card6Digits}
+                  onChange={handleInputChange}
+                  required
+                  inputProps={{ inputMode: 'numeric', pattern: '[0-9]{6}', maxLength: 6 }}
+                  helperText="The last 6 digits of any Isracard registered to this ID"
+                />
+              )}
 
               <TextField
                 fullWidth

--- a/frontend/src/components/bank/UpdateCredentialsDialog.tsx
+++ b/frontend/src/components/bank/UpdateCredentialsDialog.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material';
 import { BankAccount } from '../../services/api/types';
 import { bankAccountsApi } from '../../services/api/bank';
-import { isApiBank } from '../../constants/banks';
 
 interface UpdateCredentialsDialogProps {
   open: boolean;
@@ -32,11 +31,14 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
   const [password, setPassword] = useState('');
   const [card6Digits, setCard6Digits] = useState('');
   const [apiToken, setApiToken] = useState('');
+  const [flexToken, setFlexToken] = useState('');
+  const [queryId, setQueryId] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
 
-  const isMercury = account ? isApiBank(account.bankId) : false;
+  const isMercury = account?.bankId === 'mercury';
+  const isIbkr = account?.bankId === 'ibkr';
   const isIsracard = account?.bankId === 'isracard';
 
   const handleClose = () => {
@@ -44,6 +46,8 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
       setPassword('');
       setCard6Digits('');
       setApiToken('');
+      setFlexToken('');
+      setQueryId('');
       setError('');
       setSuccess(false);
       onClose();
@@ -58,6 +62,11 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
     if (isMercury) {
       if (!apiToken) {
         setError('API token is required');
+        return;
+      }
+    } else if (isIbkr) {
+      if (!flexToken || !queryId) {
+        setError('Flex token and Query ID are required');
         return;
       }
     } else {
@@ -79,6 +88,11 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
       if (isMercury) {
         await bankAccountsApi.updateCredentials(account._id, {
           apiToken
+        });
+      } else if (isIbkr) {
+        await bankAccountsApi.updateCredentials(account._id, {
+          flexToken,
+          queryId
         });
       } else {
         const username = account.credentials?.username || '';
@@ -160,6 +174,28 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
                 placeholder="Enter your Mercury API token"
                 helperText="Generate a new token from your Mercury dashboard"
               />
+            ) : isIbkr ? (
+              <>
+                <TextField
+                  label="Flex Web Service Token"
+                  type="password"
+                  fullWidth
+                  required
+                  value={flexToken}
+                  onChange={(e) => setFlexToken(e.target.value)}
+                  disabled={loading || success}
+                  helperText="Your token from IBKR Settings → Flex Web Service"
+                />
+                <TextField
+                  label="Flex Query ID"
+                  fullWidth
+                  required
+                  value={queryId}
+                  onChange={(e) => setQueryId(e.target.value)}
+                  disabled={loading || success}
+                  helperText="The numeric ID of your Activity Flex Query"
+                />
+              </>
             ) : (
               <>
                 <TextField
@@ -201,6 +237,8 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
             <Alert severity="info" sx={{ mt: 1 }}>
               {isMercury
                 ? 'Your API token will be encrypted and stored securely.'
+                : isIbkr
+                  ? 'Your Flex token will be encrypted and the updated connection will be synced automatically.'
                 : 'Your credentials will be validated with the bank before saving. The connection will be tested automatically.'}
             </Alert>
           </Stack>
@@ -219,11 +257,21 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
             disabled={
               loading ||
               success ||
-              (isMercury ? !apiToken : !password || (isIsracard && card6Digits.length !== 6))
+              (isMercury
+                ? !apiToken
+                : isIbkr
+                  ? !flexToken || !queryId
+                  : !password || (isIsracard && card6Digits.length !== 6))
             }
             startIcon={loading && <CircularProgress size={16} />}
           >
-            {loading ? 'Updating...' : isMercury ? 'Update Token' : 'Update Password'}
+            {loading
+              ? 'Updating...'
+              : isMercury
+                ? 'Update Token'
+                : isIbkr
+                  ? 'Update Flex Credentials'
+                  : 'Update Password'}
           </Button>
         </DialogActions>
       </form>

--- a/frontend/src/components/bank/UpdateCredentialsDialog.tsx
+++ b/frontend/src/components/bank/UpdateCredentialsDialog.tsx
@@ -30,16 +30,19 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
   onSuccess
 }) => {
   const [password, setPassword] = useState('');
+  const [card6Digits, setCard6Digits] = useState('');
   const [apiToken, setApiToken] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
 
   const isMercury = account ? isApiBank(account.bankId) : false;
+  const isIsracard = account?.bankId === 'isracard';
 
   const handleClose = () => {
     if (!loading) {
       setPassword('');
+      setCard6Digits('');
       setApiToken('');
       setError('');
       setSuccess(false);
@@ -62,6 +65,10 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
         setError('Password is required');
         return;
       }
+      if (isIsracard && !/^\d{6}$/.test(card6Digits)) {
+        setError('Enter the last 6 digits of your Isracard');
+        return;
+      }
     }
 
     setLoading(true);
@@ -82,7 +89,8 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
         }
         await bankAccountsApi.updateCredentials(account._id, {
           username,
-          password
+          password,
+          ...(isIsracard && { card6Digits })
         });
       }
       
@@ -155,13 +163,26 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
             ) : (
               <>
                 <TextField
-                  label="Username"
+                  label={isIsracard ? 'ID Number' : 'Username'}
                   type="text"
                   fullWidth
                   value={account.credentials?.username || 'N/A'}
                   disabled
-                  helperText="Username cannot be changed. Create a new account if needed."
+                  helperText={`${isIsracard ? 'ID number' : 'Username'} cannot be changed. Create a new account if needed.`}
                 />
+
+                {isIsracard && (
+                  <TextField
+                    label="Last 6 card digits"
+                    fullWidth
+                    required
+                    value={card6Digits}
+                    onChange={(e) => setCard6Digits(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                    disabled={loading || success}
+                    inputProps={{ inputMode: 'numeric', pattern: '[0-9]{6}', maxLength: 6 }}
+                    helperText="The last 6 digits of any Isracard registered to this ID"
+                  />
+                )}
 
                 <TextField
                   label="Password"
@@ -195,7 +216,11 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
           <Button
             type="submit"
             variant="contained"
-            disabled={loading || success || (isMercury ? !apiToken : !password)}
+            disabled={
+              loading ||
+              success ||
+              (isMercury ? !apiToken : !password || (isIsracard && card6Digits.length !== 6))
+            }
             startIcon={loading && <CircularProgress size={16} />}
           >
             {loading ? 'Updating...' : isMercury ? 'Update Token' : 'Update Password'}

--- a/frontend/src/components/bank/__tests__/UpdateCredentialsDialog.test.tsx
+++ b/frontend/src/components/bank/__tests__/UpdateCredentialsDialog.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { UpdateCredentialsDialog } from '../UpdateCredentialsDialog';
+import { bankAccountsApi } from '../../../services/api/bank';
+import { BankAccount } from '../../../services/api/types';
+
+jest.mock('../../../services/api/bank', () => ({
+  bankAccountsApi: {
+    updateCredentials: jest.fn()
+  }
+}));
+
+const updateCredentials = bankAccountsApi.updateCredentials as jest.MockedFunction<
+  typeof bankAccountsApi.updateCredentials
+>;
+
+const ibkrAccount = {
+  _id: 'ibkr-account',
+  bankId: 'ibkr',
+  name: 'Interactive Brokers',
+  status: 'active',
+  lastScraped: null,
+  scrapingConfig: {
+    schedule: {
+      frequency: 'daily',
+      timeOfDay: '00:00'
+    },
+    options: {
+      startDate: '2026-01-01T00:00:00.000Z',
+      monthsBack: 12
+    }
+  }
+} as BankAccount;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updateCredentials.mockResolvedValue({
+    message: 'Credentials updated successfully',
+    account: ibkrAccount
+  });
+});
+
+it('updates IBKR with Flex credentials instead of a Mercury API token', async () => {
+  const { unmount } = render(
+    <UpdateCredentialsDialog
+      open
+      account={ibkrAccount}
+      onClose={jest.fn()}
+      onSuccess={jest.fn()}
+    />
+  );
+
+  expect(screen.getByLabelText(/flex web service token/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/flex query id/i)).toBeInTheDocument();
+  expect(screen.queryByLabelText(/^api token$/i)).not.toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText(/flex web service token/i), {
+    target: { value: 'new-flex-token' }
+  });
+  fireEvent.change(screen.getByLabelText(/flex query id/i), {
+    target: { value: '12345' }
+  });
+  fireEvent.click(screen.getByRole('button', { name: /update flex credentials/i }));
+
+  await waitFor(() =>
+    expect(updateCredentials).toHaveBeenCalledWith('ibkr-account', {
+      flexToken: 'new-flex-token',
+      queryId: '12345'
+    })
+  );
+
+  unmount();
+});

--- a/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
@@ -20,7 +20,8 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
   const [form, setForm] = useState({
     bankId: suggestedProvider?.bankId || '',
     username: '',
-    password: ''
+    password: '',
+    card6Digits: ''
   });
   const [loading, setLoading] = useState(false);
   const [skipping, setSkipping] = useState(false);
@@ -35,7 +36,10 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
 
   const handleText = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
-    setForm((previous) => ({ ...previous, [name]: value }));
+    setForm((previous) => ({
+      ...previous,
+      [name]: name === 'card6Digits' ? value.replace(/\D/g, '').slice(0, 6) : value
+    }));
   };
 
   const handleProvider = (bankId: string) => {
@@ -50,13 +54,21 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
       setError('Please fill in all required fields');
       return;
     }
+    if (form.bankId === 'isracard' && !/^\d{6}$/.test(form.card6Digits)) {
+      setError('Enter the last 6 digits of your Isracard');
+      return;
+    }
 
     setLoading(true);
     try {
       const provider = CREDIT_CARD_PROVIDERS.find((candidate) => candidate.id === form.bankId);
       await handlers.connectCreditCardAccount(
         form.bankId,
-        { username: form.username, password: form.password },
+        {
+          username: form.username,
+          password: form.password,
+          ...(form.bankId === 'isracard' && { card6Digits: form.card6Digits })
+        },
         `${provider?.name || form.bankId} Credit Cards`
       );
     } catch (err) {
@@ -83,7 +95,7 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
 
   return (
     <CardShell testId="credit-card-setup">
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} noValidate>
         <BankPicker
           banks={CREDIT_CARD_PROVIDERS}
           value={form.bankId}
@@ -101,13 +113,29 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
           fullWidth
           margin="dense"
           size="small"
-          label="Username"
+          label={form.bankId === 'isracard' ? 'ID Number' : 'Username'}
           name="username"
           value={form.username}
           onChange={handleText}
           required
           data-testid="cc-username-input"
         />
+
+        {form.bankId === 'isracard' && (
+          <TextField
+            fullWidth
+            margin="dense"
+            size="small"
+            label="Last 6 card digits"
+            name="card6Digits"
+            value={form.card6Digits}
+            onChange={handleText}
+            required
+            inputProps={{ inputMode: 'numeric', pattern: '[0-9]{6}', maxLength: 6 }}
+            helperText="The last 6 digits of any Isracard registered to this ID"
+            data-testid="cc-card6-input"
+          />
+        )}
 
         <TextField
           fullWidth

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
@@ -128,17 +128,40 @@ describe('CreditCardFormCard submission', () => {
     const group = showCard();
 
     fireEvent.click(within(group).getByRole('radio', { name: 'Isracard' }));
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'someone' } });
+    fireEvent.change(screen.getByLabelText(/id number/i), { target: { value: 'someone' } });
+    fireEvent.change(screen.getByLabelText(/last 6 card digits/i), { target: { value: '123456' } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } });
     fireEvent.click(screen.getByTestId('connect-cards-btn'));
 
     await waitFor(() =>
       expect(handlers.connectCreditCardAccount).toHaveBeenCalledWith(
         'isracard',
-        { username: 'someone', password: 'secret' },
+        { username: 'someone', password: 'secret', card6Digits: '123456' },
         'Isracard Credit Cards'
       )
     );
+  });
+
+  it('requires exactly six card digits for Isracard', async () => {
+    const group = showCard();
+
+    fireEvent.click(within(group).getByRole('radio', { name: 'Isracard' }));
+    fireEvent.change(screen.getByLabelText(/id number/i), { target: { value: 'someone' } });
+    fireEvent.change(screen.getByLabelText(/last 6 card digits/i), { target: { value: '12345' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByTestId('connect-cards-btn'));
+
+    expect(await screen.findByText(/enter the last 6 digits/i)).toBeInTheDocument();
+    expect(handlers.connectCreditCardAccount).not.toHaveBeenCalled();
+  });
+
+  it('does not ask other providers for card digits', () => {
+    const group = showCard();
+
+    fireEvent.click(within(group).getByRole('radio', { name: 'Max' }));
+
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/last 6 card digits/i)).not.toBeInTheDocument();
   });
 
   // Nothing is selected on first render, so the provider is the field most

--- a/frontend/src/components/onboarding/chat/types.ts
+++ b/frontend/src/components/onboarding/chat/types.ts
@@ -37,7 +37,7 @@ export interface ChatHandlers {
   ) => Promise<unknown>;
   connectCreditCardAccount: (
     bankId: string,
-    credentials: { username: string; password: string },
+    credentials: { username: string; password: string; card6Digits?: string },
     displayName: string
   ) => Promise<unknown>;
   proceedToCreditCardSetup: () => Promise<void>;

--- a/frontend/src/services/api/bank.ts
+++ b/frontend/src/services/api/bank.ts
@@ -38,6 +38,7 @@ export const bankAccountsApi = {
     credentials: {
       username?: string;
       password?: string;
+      card6Digits?: string;
       apiToken?: string;
     }
   ): Promise<{ message: string; account: BankAccount }> => {

--- a/frontend/src/services/api/bank.ts
+++ b/frontend/src/services/api/bank.ts
@@ -40,6 +40,8 @@ export const bankAccountsApi = {
       password?: string;
       card6Digits?: string;
       apiToken?: string;
+      flexToken?: string;
+      queryId?: string;
     }
   ): Promise<{ message: string; account: BankAccount }> => {
     const response = await api.put(`/bank-accounts/${id}/credentials`, credentials);

--- a/frontend/src/services/api/types/bankAccount.ts
+++ b/frontend/src/services/api/types/bankAccount.ts
@@ -42,6 +42,7 @@ export interface AddBankAccountDto {
   credentials: {
     username?: string;
     password?: string;
+    card6Digits?: string;
     apiToken?: string;
     flexToken?: string;
     queryId?: string;


### PR DESCRIPTION
## What Changed
- Added an Isracard-specific credential adapter that sends `{ id, card6Digits, password }` to `israeli-bank-scrapers` while preserving the existing internal username field.
- Added last-six collection and validation to onboarding, account creation, and credential updates.
- Encrypts the card suffix at rest and excludes it from API serialization.
- Updated scraper mocks and regression coverage for creation, validation, persistence, updates, and onboarding submission.

## Why
Isracard now requires the final six card digits in addition to the account ID and password. GeriFinancial previously sent only generic username/password credentials, preventing new Isracard connections.

## Impact Analysis
- Behavior changes only for Isracard credentials; other providers retain their existing credential shape.
- No new dependencies or performance impact.
- The additional credential field uses the existing per-user envelope encryption path.

## Quality Gates
- Backend: 61 suites passed, 1,229 tests passed.
- Frontend: 29 suites passed, 320 tests passed.
- Frontend lint, TypeScript checking, and production build passed.

## Deployment Considerations
No data migration or configuration changes are required. There are no existing Isracard credentials to backfill.