### PR TITLE
bugfix(banking): surface actionable scraper errors

### DIFF
--- a/backend/src/banking/services/sync-strategies/IsraeliScraperSyncStrategy.js
+++ b/backend/src/banking/services/sync-strategies/IsraeliScraperSyncStrategy.js
@@ -1,6 +1,34 @@
 const logger = require('../../../shared/utils/logger');
 const BaseSyncStrategy = require('./BaseSyncStrategy');
 
+const SCRAPER_ERROR_MESSAGES = {
+  TWO_FACTOR_RETRIEVER_MISSING: 'Two-factor authentication is required for this account',
+  INVALID_PASSWORD: 'Invalid bank credentials',
+  CHANGE_PASSWORD: 'The bank requires a password change. Sign in to the bank website, change the password, then update the saved credentials',
+  TIMEOUT: 'The bank website took too long to respond',
+  ACCOUNT_BLOCKED: 'The bank account is blocked. Contact the bank before retrying',
+  GENERIC: 'The bank scraper encountered an unexpected error',
+  GENERAL_ERROR: 'The bank website returned an unexpected login error'
+};
+
+function getScraperErrorMessage(scrapingResult) {
+  const errorMessage = typeof scrapingResult.errorMessage === 'string'
+    ? scrapingResult.errorMessage.trim()
+    : '';
+
+  if (errorMessage) {
+    return errorMessage;
+  }
+
+  if (SCRAPER_ERROR_MESSAGES[scrapingResult.errorType]) {
+    return SCRAPER_ERROR_MESSAGES[scrapingResult.errorType];
+  }
+
+  return scrapingResult.errorType
+    ? `Scraper failed with error type ${scrapingResult.errorType}`
+    : 'Scraper failed without error details';
+}
+
 /**
  * Sync strategy for banks that use the israeli-bank-scrapers library.
  * Handles scraper creation, login, and the scrape→process pipeline.
@@ -62,7 +90,7 @@ class IsraeliScraperSyncStrategy extends BaseSyncStrategy {
       const scrapingResult = await scraper[this.scrapingMethod](credentials);
       
       if (!scrapingResult.success) {
-        throw new Error(`${this.displayName} scraping failed: ${scrapingResult.errorMessage || 'Unknown error'}`);
+        throw new Error(`${this.displayName} scraping failed: ${getScraperErrorMessage(scrapingResult)}`);
       }
       
       const processedResults = await this.processScrapedData(scrapingResult, bankAccount, context);

--- a/backend/src/banking/services/sync-strategies/IsraeliScraperSyncStrategy.js
+++ b/backend/src/banking/services/sync-strategies/IsraeliScraperSyncStrategy.js
@@ -12,7 +12,7 @@ const SCRAPER_ERROR_MESSAGES = {
 };
 
 function getScraperErrorMessage(scrapingResult) {
-  const errorMessage = typeof scrapingResult.errorMessage === 'string'
+  const errorMessage = typeof scrapingResult?.errorMessage === 'string'
     ? scrapingResult.errorMessage.trim()
     : '';
 
@@ -20,12 +20,16 @@ function getScraperErrorMessage(scrapingResult) {
     return errorMessage;
   }
 
-  if (SCRAPER_ERROR_MESSAGES[scrapingResult.errorType]) {
-    return SCRAPER_ERROR_MESSAGES[scrapingResult.errorType];
+  const errorType = typeof scrapingResult?.errorType === 'string'
+    ? scrapingResult.errorType.trim()
+    : '';
+
+  if (Object.prototype.hasOwnProperty.call(SCRAPER_ERROR_MESSAGES, errorType)) {
+    return SCRAPER_ERROR_MESSAGES[errorType];
   }
 
-  return scrapingResult.errorType
-    ? `Scraper failed with error type ${scrapingResult.errorType}`
+  return errorType
+    ? `Scraper failed with error type ${errorType}`
     : 'Scraper failed without error details';
 }
 
@@ -89,7 +93,7 @@ class IsraeliScraperSyncStrategy extends BaseSyncStrategy {
       
       const scrapingResult = await scraper[this.scrapingMethod](credentials);
       
-      if (!scrapingResult.success) {
+      if (!scrapingResult?.success) {
         throw new Error(`${this.displayName} scraping failed: ${getScraperErrorMessage(scrapingResult)}`);
       }
       

--- a/backend/src/banking/services/sync-strategies/__tests__/IsraeliScraperSyncStrategy.test.js
+++ b/backend/src/banking/services/sync-strategies/__tests__/IsraeliScraperSyncStrategy.test.js
@@ -87,4 +87,30 @@ describe('IsraeliScraperSyncStrategy', () => {
       'Checking Accounts scraping failed: Scraper failed with error type NEW_SCRAPER_ERROR'
     );
   });
+
+  it('does not read inherited properties as scraper error messages', async () => {
+    bankScraperService.createScraper.mockReturnValue({
+      scrape: jest.fn().mockResolvedValue({
+        success: false,
+        errorType: '__proto__'
+      })
+    });
+
+    await expect(strategy.executeSync(bankAccount, {}, {})).rejects.toThrow(
+      'Checking Accounts scraping failed: Scraper failed with error type __proto__'
+    );
+  });
+
+  it.each([
+    ['a null result', null],
+    ['a non-string error type', { success: false, errorType: { code: 'CHANGE_PASSWORD' } }]
+  ])('handles %s without throwing a type error', async (_description, scrapingResult) => {
+    bankScraperService.createScraper.mockReturnValue({
+      scrape: jest.fn().mockResolvedValue(scrapingResult)
+    });
+
+    await expect(strategy.executeSync(bankAccount, {}, {})).rejects.toThrow(
+      'Checking Accounts scraping failed: Scraper failed without error details'
+    );
+  });
 });

--- a/backend/src/banking/services/sync-strategies/__tests__/IsraeliScraperSyncStrategy.test.js
+++ b/backend/src/banking/services/sync-strategies/__tests__/IsraeliScraperSyncStrategy.test.js
@@ -1,0 +1,90 @@
+jest.mock('../../bankScraperService', () => ({
+  createScraper: jest.fn(),
+  updateScrapingStatus: jest.fn()
+}));
+
+const bankScraperService = require('../../bankScraperService');
+const IsraeliScraperSyncStrategy = require('../IsraeliScraperSyncStrategy');
+
+class TestSyncStrategy extends IsraeliScraperSyncStrategy {
+  constructor() {
+    super({
+      name: 'checking-accounts',
+      displayName: 'Checking Accounts',
+      icon: 'test',
+      scrapingMethod: 'scrape',
+      statusUpdates: {
+        error: error => ({ message: error })
+      }
+    });
+  }
+
+  isSupported() {
+    return true;
+  }
+
+  getEmptyResult() {
+    return {};
+  }
+
+  async processScrapedData() {
+    return {};
+  }
+}
+
+describe('IsraeliScraperSyncStrategy', () => {
+  let strategy;
+  let bankAccount;
+
+  beforeEach(() => {
+    strategy = new TestSyncStrategy();
+    bankAccount = {
+      _id: 'account-1',
+      bankId: 'visaCal',
+      getScraperOptionsForStrategy: jest.fn().mockResolvedValue({
+        credentials: { username: 'user', password: 'password' },
+        startDate: new Date('2026-01-01T00:00:00.000Z')
+      })
+    };
+  });
+
+  it('reports a required password change instead of an unknown error', async () => {
+    bankScraperService.createScraper.mockReturnValue({
+      scrape: jest.fn().mockResolvedValue({
+        success: false,
+        errorType: 'CHANGE_PASSWORD'
+      })
+    });
+
+    await expect(strategy.executeSync(bankAccount, {}, {})).rejects.toThrow(
+      'Checking Accounts scraping failed: The bank requires a password change. Sign in to the bank website, change the password, then update the saved credentials'
+    );
+  });
+
+  it('preserves a detailed error message returned by the scraper', async () => {
+    bankScraperService.createScraper.mockReturnValue({
+      scrape: jest.fn().mockResolvedValue({
+        success: false,
+        errorType: 'GENERAL_ERROR',
+        errorMessage: 'CAL login is temporarily unavailable'
+      })
+    });
+
+    await expect(strategy.executeSync(bankAccount, {}, {})).rejects.toThrow(
+      'Checking Accounts scraping failed: CAL login is temporarily unavailable'
+    );
+  });
+
+  it('includes an unmapped scraper error type in the failure', async () => {
+    bankScraperService.createScraper.mockReturnValue({
+      scrape: jest.fn().mockResolvedValue({
+        success: false,
+        errorType: 'NEW_SCRAPER_ERROR'
+      })
+    });
+
+    await expect(strategy.executeSync(bankAccount, {}, {})).rejects.toThrow(
+      'Checking Accounts scraping failed: Scraper failed with error type NEW_SCRAPER_ERROR'
+    );
+  });
+});


### PR DESCRIPTION
## What Changed
- Map known `israeli-bank-scrapers` error types to actionable application messages when the scraper does not provide `errorMessage`.
- Preserve detailed scraper messages and include unknown future error types instead of falling back to `Unknown error`.
- Add focused strategy tests for password-change, detailed-message, and unmapped-error cases.

## Why
- Visa CAL correctly returned `CHANGE_PASSWORD` for the second onboarding account, but GeriFinancial displayed `Checking Accounts scraping failed: Unknown error`.
- Users now receive the required remediation: change the password on the bank website, update saved credentials, and retry.

## Impact Analysis
- No dependency, schema, migration, or API contract changes.
- Existing scraper-provided error messages remain unchanged.

## Quality Gates
- Backend: 62 suites passed; 1,239 tests passed and 6 skipped.
- Frontend tests, lint, type-check, and production build passed.
- Added 3 backend regression tests.

## Deployment Considerations
- No configuration or migration steps required.