### PR TITLE
bugfix(onboarding): recover from failed card imports

### DIFF
--- a/backend/src/auth/models/User.js
+++ b/backend/src/auth/models/User.js
@@ -208,6 +208,15 @@ const userSchema = new mongoose.Schema({
         type: Date,
         default: null
       },
+      error: {
+        type: String,
+        default: null
+      },
+      processingAccountId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'BankAccount',
+        default: null
+      },
       totalCreditCardPayments: {
         type: Number,
         default: 0

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -200,6 +200,10 @@ describe('Onboarding Accounts API', () => {
         .toBe(mockAccount._id.toString());
       expect(updatedUser.onboarding.creditCardSetup.creditCardAccounts[0].bankId).toBe('isracard');
       expect(updatedUser.onboarding.currentStep).toBe('credit-card-matching');
+      expect(updatedUser.onboarding.creditCardMatching.completed).toBe(false);
+      expect(updatedUser.onboarding.creditCardMatching.processingAccountId.toString())
+        .toBe(mockAccount._id.toString());
+      expect(updatedUser.onboarding.creditCardMatching.error).toBeNull();
     });
 
     it('should allow adding multiple credit card accounts', async () => {

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -715,4 +715,81 @@ describe('Onboarding Event Handlers', () => {
       expect(creditCardDetectionService.analyzeCreditCardCoverage).not.toHaveBeenCalled();
     });
   });
+
+  describe('checking-accounts:failed event', () => {
+    it('restores the matching review when the card currently being added fails', async () => {
+      testUser.onboarding = {
+        startedAt: new Date(),
+        currentStep: 'credit-card-matching',
+        isComplete: false,
+        checkingAccount: {
+          connected: true,
+          accountId: checkingAccountId,
+          connectedAt: new Date(),
+          bankId: 'hapoalim'
+        },
+        creditCardSetup: {
+          skipped: false,
+          creditCardAccounts: [{
+            accountId: creditCardAccountId,
+            connectedAt: new Date(),
+            bankId: 'isracard',
+            displayName: 'Isracard'
+          }]
+        },
+        creditCardMatching: {
+          completed: false,
+          completedAt: null,
+          processingAccountId: creditCardAccountId,
+          totalCreditCardPayments: 5,
+          coveredPayments: 2,
+          uncoveredPayments: 3,
+          coveragePercentage: 40,
+          matchedPayments: []
+        },
+        completedSteps: [
+          'checking-account',
+          'transaction-import',
+          'credit-card-detection',
+          'credit-card-setup',
+          'credit-card-matching'
+        ]
+      };
+      await testUser.save();
+
+      const emit = jest.spyOn(scrapingEvents, 'emit');
+
+      scrapingEvents.emit('checking-accounts:failed', {
+        strategyName: 'checking-accounts',
+        bankAccountId: creditCardAccountId,
+        userId: testUser._id,
+        error: new Error(
+          'Checking Accounts scraping failed: The bank requires a password change. Sign in to the bank website and change it'
+        )
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.creditCardMatching).toEqual(expect.objectContaining({
+        completed: true,
+        error: 'Isracard could not be imported. The bank requires a password change. Sign in to the bank website and change it',
+        totalCreditCardPayments: 5,
+        coveredPayments: 2,
+        uncoveredPayments: 3,
+        coveragePercentage: 40
+      }));
+      expect(updatedUser.onboarding.creditCardMatching.processingAccountId).toBeFalsy();
+      expect(updatedUser.onboarding.currentStep).toBe('credit-card-matching');
+      expect(updatedUser.onboarding.isComplete).toBe(false);
+      expect(emit).toHaveBeenCalledWith('credit-card-matching:completed', {
+        userId: testUser._id,
+        matchingResults: {
+          coveredCount: 2,
+          uncoveredCount: 3,
+          coveragePercentage: 40
+        }
+      });
+    });
+  });
 });

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -141,7 +141,8 @@ router.post('/credit-card-account', auth, async (req, res) => {
         'onboarding.currentStep': 'credit-card-matching',
         'onboarding.creditCardMatching.completed': false, // Mark as not completed
         'onboarding.creditCardMatching.processingAccountId': bankAccount._id, // Track which account is being processed
-        'onboarding.creditCardMatching.completedAt': null
+        'onboarding.creditCardMatching.completedAt': null,
+        'onboarding.creditCardMatching.error': null
       }
     });
     

--- a/backend/src/onboarding/services/onboardingEventHandlers.js
+++ b/backend/src/onboarding/services/onboardingEventHandlers.js
@@ -585,6 +585,7 @@ class OnboardingEventHandlers {
    */
   async handleCheckingAccountsFailed(data) {
     const { strategyName, bankAccountId, userId, error } = data;
+    const errorMessage = error?.message || 'Unknown error';
     
     logger.info(`📬 Onboarding: Received checking-accounts failed event for account ${bankAccountId}`);
     
@@ -600,7 +601,7 @@ class OnboardingEventHandlers {
         isActive: false,
         status: 'error',
         progress: 0,
-        message: `Import failed: ${error.message || 'Unknown error'}`,
+        message: `Import failed: ${errorMessage}`,
         startedAt: bankAccount.scrapingStatus?.startedAt || new Date(),
         lastUpdatedAt: new Date(),
         transactionsImported: 0,
@@ -608,6 +609,51 @@ class OnboardingEventHandlers {
       };
 
       await bankAccount.save();
+
+      const user = await User.findById(userId);
+      const onboardingCreditCards = user?.onboarding?.creditCardSetup?.creditCardAccounts || [];
+      const isOnboardingCreditCard = onboardingCreditCards.some(
+        account => account.accountId?.toString() === bankAccountId.toString()
+      );
+      const matching = user?.onboarding?.creditCardMatching;
+      const processingAccountId = matching?.processingAccountId?.toString();
+      const isTrackedAccount = !processingAccountId || processingAccountId === bankAccountId.toString();
+
+      if (
+        user
+        && !user.onboarding?.isComplete
+        && user.onboarding?.currentStep === 'credit-card-matching'
+        && matching?.completed === false
+        && isOnboardingCreditCard
+        && isTrackedAccount
+      ) {
+        const providerName = bankAccount.displayName || bankAccount.name || 'Credit card account';
+        const failureReason = errorMessage.replace(/^Checking Accounts scraping failed:\s*/, '');
+        const matchingError = `${providerName} could not be imported. ${failureReason}`;
+        const completedAt = new Date();
+
+        await User.findByIdAndUpdate(userId, {
+          $set: {
+            'onboarding.creditCardMatching.completed': true,
+            'onboarding.creditCardMatching.completedAt': completedAt,
+            'onboarding.creditCardMatching.error': matchingError
+          },
+          $unset: {
+            'onboarding.creditCardMatching.processingAccountId': ''
+          }
+        });
+
+        scrapingEvents.emit('credit-card-matching:completed', {
+          userId,
+          matchingResults: {
+            coveredCount: matching.coveredPayments,
+            uncoveredCount: matching.uncoveredPayments,
+            coveragePercentage: matching.coveragePercentage
+          }
+        });
+
+        logger.info(`✅ Onboarding: Restored matching review after card import failure for account ${bankAccountId}`);
+      }
       
       logger.info(`✅ Onboarding: Updated scraping status to error for account ${bankAccountId}`);
     } catch (err) {

--- a/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
+++ b/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
@@ -222,6 +222,70 @@ describe('OnboardingChat', () => {
     expect(Number(bar.getAttribute('aria-valuenow'))).toBeLessThan(100);
   });
 
+  it('separates provider-level matches from connected card endings', async () => {
+    mockStatus = {
+      ...importing(),
+      currentStep: 'credit-card-matching',
+      completedSteps: ['checking-account', 'transaction-import', 'credit-card-detection', 'credit-card-setup'],
+      transactionImport: {
+        completed: true,
+        transactionsImported: 42,
+        completedAt: '2026-01-01T00:05:00Z',
+        scrapingStatus: { isActive: false, status: 'complete', progress: 100, message: null, error: null }
+      },
+      creditCardDetection: {
+        analyzed: true,
+        analyzedAt: '2026-01-01T00:06:00Z',
+        transactionCount: 5,
+        recommendation: 'connect',
+        sampleTransactions: []
+      },
+      creditCardSetup: {
+        skipped: false,
+        skippedAt: null,
+        creditCardAccounts: []
+      },
+      creditCardMatching: {
+        completed: true,
+        completedAt: '2026-01-01T00:08:00Z',
+        totalCreditCardPayments: 5,
+        coveredPayments: 2,
+        uncoveredPayments: 3,
+        coveragePercentage: 40,
+        matchedPayments: [{
+          payment: {
+            id: 'payment-1',
+            date: '2026-08-10T00:00:00.000Z',
+            description: 'Card payment',
+            amount: 34208.45
+          },
+          matchedCreditCard: {
+            id: 'card-1',
+            displayName: 'Visa Cal Credit Cards',
+            cardNumber: '0296',
+            lastFourDigits: '0296',
+            provider: 'visaCal'
+          },
+          matchedMonth: '2026-08',
+          matchConfidence: 91
+        }],
+        connectedCreditCards: [
+          { id: 'card-1', displayName: '0296', provider: 'visaCal' },
+          { id: 'card-2', displayName: '4940', provider: 'visaCal' }
+        ]
+      }
+    };
+    draw();
+
+    expect(await screen.findByText('Matched checking-account payments')).toBeInTheDocument();
+    expect(screen.getByText(/34,208\.45/)).toBeInTheDocument();
+    expect(screen.getByText('Matched to Visa Cal')).toBeInTheDocument();
+    expect(screen.getByText('Connected cards (last 4 digits)')).toBeInTheDocument();
+    expect(screen.getByText('ending 0296')).toBeInTheDocument();
+    expect(screen.getByText('ending 4940')).toBeInTheDocument();
+    expect(screen.getByText(/cannot always be assigned to one card ending/)).toBeInTheDocument();
+  });
+
   it('shows full progress once onboarding is complete', async () => {
     mockStatus = { ...importing(), currentStep: 'complete', isComplete: true };
     draw();

--- a/frontend/src/components/onboarding/chat/__tests__/script.test.ts
+++ b/frontend/src/components/onboarding/chat/__tests__/script.test.ts
@@ -285,6 +285,36 @@ describe('buildScript', () => {
     expect(textOf(script)).not.toContain("probably on a card you haven't connected");
   });
 
+  it('returns to the matching review when a card import fails', () => {
+    const script = buildScript(
+      imported({
+        currentStep: 'credit-card-matching',
+        creditCardDetection: {
+          analyzed: true,
+          analyzedAt: '2026-01-01T00:06:00Z',
+          transactionCount: 5,
+          recommendation: 'connect',
+          sampleTransactions: []
+        },
+        creditCardMatching: {
+          completed: true,
+          completedAt: '2026-01-01T00:09:00Z',
+          error: 'Visa Cal could not be imported. The bank requires a password change.',
+          totalCreditCardPayments: 5,
+          coveredPayments: 2,
+          uncoveredPayments: 3,
+          coveragePercentage: 40,
+          matchedPayments: []
+        }
+      })
+    );
+
+    expect(textOf(script)).toContain('Visa Cal could not be imported');
+    expect(textOf(script)).toContain('2 of 5');
+    expect(cardsOf(script)).toEqual(['matching-review']);
+    expect(script.waiting).toBe(false);
+  });
+
   it('ends on the completion card', () => {
     const script = buildScript(
       imported({

--- a/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
@@ -9,13 +9,14 @@ import { formatCurrencyDisplay } from '../../../../utils/formatters';
 const providerName = (provider: string): string =>
   CREDIT_CARD_PROVIDERS.find((candidate) => candidate.id === provider)?.name || provider;
 
-const formatPaymentDate = (date: string): string =>
-  new Intl.DateTimeFormat('en-IL', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    timeZone: 'Asia/Jerusalem'
-  }).format(new Date(date));
+const PAYMENT_DATE_FORMATTER = new Intl.DateTimeFormat('en-IL', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'Asia/Jerusalem'
+});
+
+const formatPaymentDate = (date: string): string => PAYMENT_DATE_FORMATTER.format(new Date(date));
 
 /**
  * Shown once the card statements have been matched against the payments in the

--- a/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
@@ -3,6 +3,19 @@ import { Box, Button, Typography, Stack, LinearProgress, Chip } from '@mui/mater
 import { Add as AddIcon, CreditCard as CreditCardIcon } from '@mui/icons-material';
 import { CardShell } from '../CardShell';
 import { CardProps } from '../types';
+import { CREDIT_CARD_PROVIDERS } from '../../../../constants/banks';
+import { formatCurrencyDisplay } from '../../../../utils/formatters';
+
+const providerName = (provider: string): string =>
+  CREDIT_CARD_PROVIDERS.find((candidate) => candidate.id === provider)?.name || provider;
+
+const formatPaymentDate = (date: string): string =>
+  new Intl.DateTimeFormat('en-IL', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Asia/Jerusalem'
+  }).format(new Date(date));
 
 /**
  * Shown once the card statements have been matched against the payments in the
@@ -13,6 +26,7 @@ export const MatchingReviewCard: React.FC<CardProps> = ({ status, handlers }) =>
   const [busy, setBusy] = useState<'more' | 'finish' | null>(null);
   const matching = status.creditCardMatching;
   const cards = matching?.connectedCreditCards || [];
+  const matchedPayments = matching?.matchedPayments || [];
   const percentage = Math.round(matching?.coveragePercentage || 0);
 
   const run = async (action: 'more' | 'finish') => {
@@ -45,12 +59,45 @@ export const MatchingReviewCard: React.FC<CardProps> = ({ status, handlers }) =>
         </Box>
       )}
 
+      {matchedPayments.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Matched checking-account payments
+          </Typography>
+          <Stack spacing={1}>
+            {matchedPayments.map((match) => (
+              <Box key={match.payment.id}>
+                <Typography variant="body2">
+                  {formatPaymentDate(match.payment.date)} · {formatCurrencyDisplay(match.payment.amount)}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Matched to {providerName(match.matchedCreditCard.provider)}
+                </Typography>
+              </Box>
+            ))}
+          </Stack>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+            A provider debit can combine several physical cards, so it cannot always be assigned to one card ending.
+          </Typography>
+        </Box>
+      )}
+
       {cards.length > 0 && (
-        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1, mb: 2 }}>
-          {cards.map((card) => (
-            <Chip key={card.id} icon={<CreditCardIcon />} label={card.displayName} size="small" />
-          ))}
-        </Stack>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Connected cards (last 4 digits)
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
+            {cards.map((card) => (
+              <Chip
+                key={card.id}
+                icon={<CreditCardIcon />}
+                label={`ending ${card.displayName}`}
+                size="small"
+              />
+            ))}
+          </Stack>
+        </Box>
       )}
 
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>

--- a/frontend/src/components/onboarding/chat/script.ts
+++ b/frontend/src/components/onboarding/chat/script.ts
@@ -94,7 +94,12 @@ export const buildScript = (status: OnboardingStatus | null): Script => {
       say('matching', "Now I'm checking those cards against the payments in your checking account.");
       return pause();
     }
-    say('matched', describeMatching(matching));
+    if (matching.error) {
+      say('matching-error', matching.error);
+    }
+    if (!matching.error || matching.totalCreditCardPayments > 0) {
+      say('matched', describeMatching(matching));
+    }
     return offer('matching-review');
   }
 
@@ -145,7 +150,7 @@ const describeMatching = (matching: OnboardingStatus['creditCardMatching']): str
   const percentage = Math.round(matching.coveragePercentage || 0);
   const covered = `${matching.coveredPayments} of ${total}`;
   if (percentage >= 80) {
-    return `Matched ${covered} of your credit card payments to a card - that covers ${percentage}% of them.`;
+    return `Matched ${covered} of your credit card payments with your connected card providers - that covers ${percentage}% of them.`;
   }
   return `I matched ${covered} of your credit card payments, or ${percentage}%. I couldn't confidently reconcile the rest with the connected providers.`;
 };

--- a/frontend/src/services/api/onboarding.ts
+++ b/frontend/src/services/api/onboarding.ts
@@ -65,6 +65,7 @@ export interface OnboardingStatus {
   creditCardMatching: {
     completed: boolean;
     completedAt: string | null;
+    error?: string | null;
     totalCreditCardPayments: number;
     coveredPayments: number;
     uncoveredPayments: number;


### PR DESCRIPTION
## What Changed
- Track the credit-card account currently being processed and persist an onboarding matching error.
- When that card import fails, restore the previous matching result, clear the processing marker, and emit a post-update event so the chat refetches instead of waiting forever.
- Show matched checking-account payment rows separately from connected card endings, with an explanation that provider debits can combine several physical cards.
- Label connected cards explicitly as last-four-digit endings.

## Why
- A failed second Visa Cal import left `creditCardMatching.completed` false, trapping onboarding on a permanent typing indicator even though a valid 40% result already existed.
- The unlabeled values `0296`, `4940`, and similar were connected physical card endings, not seven individual payment matches.

## Impact Analysis
- Adds optional fields to the existing onboarding subdocument; no data migration or dependency change is required.
- Existing successful matching behavior remains unchanged.

## Quality Gates
- Backend: 62 suites passed; 1,243 tests passed and 6 skipped.
- Frontend: 30 suites and 324 tests passed.
- Frontend lint, type-check, and production build passed.

## Deployment Considerations
- No configuration or migration steps required.
- The affected production onboarding record was restored to its saved 40% matching review; deployment makes failure recovery automatic for future imports.