### PR TITLE
bugfix(onboarding): add failed card account actions

### DIFF
--- a/backend/src/auth/models/User.js
+++ b/backend/src/auth/models/User.js
@@ -217,6 +217,19 @@ const userSchema = new mongoose.Schema({
         ref: 'BankAccount',
         default: null
       },
+      failedAccount: {
+        type: {
+          accountId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'BankAccount'
+          },
+          bankId: String,
+          displayName: String,
+          error: String
+        },
+        default: null,
+        _id: false
+      },
       totalCreditCardPayments: {
         type: Number,
         default: 0

--- a/backend/src/banking/services/__tests__/bankAccountService.test.js
+++ b/backend/src/banking/services/__tests__/bankAccountService.test.js
@@ -281,6 +281,45 @@ describe('BankAccountService', () => {
     });
   });
 
+  describe('updateCredentials', () => {
+    it('surfaces a required retry queue failure without leaving the account active', async () => {
+      const account = await BankAccount.create({
+        userId,
+        bankId: mockAccountData.bankId,
+        name: mockAccountData.name,
+        credentials: {
+          username: mockAccountData.username,
+          password: mockAccountData.password
+        },
+        status: 'error'
+      });
+      bankScraperService.validateCredentials.mockResolvedValueOnce(true);
+      queuedDataSyncService.queueBankAccountSync.mockRejectedValueOnce(new Error('Queue unavailable'));
+
+      await expect(bankAccountService.updateCredentials(
+        account._id,
+        userId,
+        {
+          username: 'new-user',
+          password: 'new-password'
+        },
+        { requireQueuedSync: true }
+      )).rejects.toMatchObject({
+        code: 'SYNC_QUEUE_FAILED',
+        message: expect.stringContaining('Queue unavailable')
+      });
+
+      const updatedAccount = await BankAccount.findById(account._id);
+      expect(updatedAccount.status).toBe('error');
+      expect(updatedAccount.lastError.message)
+        .toBe('Credentials were updated, but the automatic import retry could not be started');
+      expect((await updatedAccount.getScraperOptions()).credentials).toEqual({
+        username: 'new-user',
+        password: 'new-password'
+      });
+    });
+  });
+
   describe('recoverMissingTransactions', () => {
     let account;
 

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -126,7 +126,7 @@ class BankAccountService {
     apiToken,
     flexToken,
     queryId
-  }) {
+  }, { requireQueuedSync = false } = {}) {
     const bankAccount = await BankAccount.findOne({ _id: accountId, userId });
     if (!bankAccount) {
       throw new Error('Bank account not found');
@@ -172,7 +172,20 @@ class BankAccountService {
       logger.info(`Queued scraping job for account ${bankAccount.name} after credential update`);
     } catch (error) {
       logger.error(`Failed to queue scraping after credential update for account ${bankAccount.name}:`, error);
-      // Don't throw error - credential update was successful
+      if (requireQueuedSync) {
+        bankAccount.status = 'error';
+        bankAccount.lastError = {
+          message: 'Credentials were updated, but the automatic import retry could not be started',
+          date: new Date()
+        };
+        await bankAccount.save();
+
+        const retryError = new Error(
+          `Credentials were updated, but the automatic import retry could not be started: ${error.message}`
+        );
+        retryError.code = 'SYNC_QUEUE_FAILED';
+        throw retryError;
+      }
     }
 
     return bankAccount;

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -13,7 +13,9 @@ jest.mock('../../banking', () => {
   return {
     ...actual,
     bankAccountService: {
-      create: jest.fn()
+      create: jest.fn(),
+      updateCredentials: jest.fn(),
+      delete: jest.fn()
     }
   };
 });
@@ -268,6 +270,136 @@ describe('Onboarding Accounts API', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toBe('Last 6 card digits must be exactly 6 digits');
       expect(bankAccountService.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failed onboarding credit card actions', () => {
+    let failedAccountId;
+
+    beforeEach(async () => {
+      failedAccountId = new mongoose.Types.ObjectId();
+      testUser.onboarding = {
+        startedAt: new Date(),
+        currentStep: 'credit-card-matching',
+        isComplete: false,
+        creditCardSetup: {
+          skipped: false,
+          creditCardAccounts: [{
+            accountId: failedAccountId,
+            connectedAt: new Date(),
+            bankId: 'visaCal',
+            displayName: 'Visa Cal Credit Cards'
+          }]
+        },
+        creditCardMatching: {
+          completed: true,
+          completedAt: new Date(),
+          error: 'Visa Cal Credit Cards could not be imported.',
+          failedAccount: {
+            accountId: failedAccountId,
+            bankId: 'visaCal',
+            displayName: 'Visa Cal Credit Cards',
+            error: 'The bank requires a password change.'
+          },
+          totalCreditCardPayments: 5,
+          coveredPayments: 2,
+          uncoveredPayments: 3,
+          coveragePercentage: 40,
+          matchedPayments: []
+        }
+      };
+      await testUser.save();
+    });
+
+    it('updates credentials and returns the account to processing', async () => {
+      bankAccountService.updateCredentials.mockResolvedValue({
+        _id: failedAccountId
+      });
+
+      const response = await request(app)
+        .put(`/api/onboarding/credit-card-account/${failedAccountId}/credentials`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          username: 'cal-user',
+          password: 'new-password'
+        });
+
+      expect(response.status).toBe(200);
+      expect(bankAccountService.updateCredentials).toHaveBeenCalledWith(
+        failedAccountId.toString(),
+        testUser._id,
+        {
+          username: 'cal-user',
+          password: 'new-password',
+          card6Digits: undefined
+        },
+        { requireQueuedSync: true }
+      );
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.creditCardMatching.completed).toBe(false);
+      expect(updatedUser.onboarding.creditCardMatching.processingAccountId.toString())
+        .toBe(failedAccountId.toString());
+      expect(updatedUser.onboarding.creditCardMatching.error).toBeNull();
+      expect(updatedUser.onboarding.creditCardMatching.failedAccount).toBeNull();
+    });
+
+    it('restores the failed account when the retry cannot be queued', async () => {
+      const queueError = new Error(
+        'Credentials were updated, but the automatic import retry could not be started: Queue unavailable'
+      );
+      queueError.code = 'SYNC_QUEUE_FAILED';
+      bankAccountService.updateCredentials.mockRejectedValue(queueError);
+
+      const response = await request(app)
+        .put(`/api/onboarding/credit-card-account/${failedAccountId}/credentials`)
+        .set('Authorization', ['Bearer', authToken].join(' '))
+        .send({
+          username: 'cal-user',
+          password: 'new-password'
+        });
+
+      expect(response.status).toBe(503);
+      expect(response.body.error)
+        .toBe('Credentials updated, but the card import retry could not be started');
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.creditCardMatching.completed).toBe(true);
+      expect(updatedUser.onboarding.creditCardMatching.processingAccountId).toBeNull();
+      expect(updatedUser.onboarding.creditCardMatching.failedAccount).toEqual(
+        expect.objectContaining({
+          accountId: failedAccountId,
+          bankId: 'visaCal',
+          displayName: 'Visa Cal Credit Cards',
+          error: expect.stringContaining('Queue unavailable')
+        })
+      );
+    });
+
+    it('removes the failed account and preserves the previous matching result', async () => {
+      bankAccountService.delete.mockResolvedValue(true);
+
+      const response = await request(app)
+        .delete(`/api/onboarding/credit-card-account/${failedAccountId}`)
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(response.status).toBe(200);
+      expect(bankAccountService.delete).toHaveBeenCalledWith(
+        failedAccountId.toString(),
+        testUser._id
+      );
+
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.creditCardSetup.creditCardAccounts).toHaveLength(0);
+      expect(updatedUser.onboarding.creditCardMatching).toEqual(expect.objectContaining({
+        completed: true,
+        error: null,
+        totalCreditCardPayments: 5,
+        coveredPayments: 2,
+        uncoveredPayments: 3,
+        coveragePercentage: 40
+      }));
+      expect(updatedUser.onboarding.creditCardMatching.failedAccount).toBeNull();
     });
   });
 

--- a/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
+++ b/backend/src/onboarding/__tests__/onboardingEventHandlers.test.js
@@ -780,6 +780,12 @@ describe('Onboarding Event Handlers', () => {
         coveragePercentage: 40
       }));
       expect(updatedUser.onboarding.creditCardMatching.processingAccountId).toBeFalsy();
+      expect(updatedUser.onboarding.creditCardMatching.failedAccount).toEqual(expect.objectContaining({
+        accountId: creditCardAccountId,
+        bankId: 'isracard',
+        displayName: 'Isracard',
+        error: 'The bank requires a password change. Sign in to the bank website and change it'
+      }));
       expect(updatedUser.onboarding.currentStep).toBe('credit-card-matching');
       expect(updatedUser.onboarding.isComplete).toBe(false);
       expect(emit).toHaveBeenCalledWith('credit-card-matching:completed', {

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const auth = require('../../shared/middleware/auth');
 const logger = require('../../shared/utils/logger');
 const { User } = require('../../auth');
-const { bankAccountService, Transaction } = require('../../banking');
+const { bankAccountService, Transaction, scrapingEvents } = require('../../banking');
 const onboardingCreditCardDetectionService = require('../services/onboardingCreditCardDetectionService');
 const {
   ISRACARD_BANK_ID,
@@ -142,7 +142,8 @@ router.post('/credit-card-account', auth, async (req, res) => {
         'onboarding.creditCardMatching.completed': false, // Mark as not completed
         'onboarding.creditCardMatching.processingAccountId': bankAccount._id, // Track which account is being processed
         'onboarding.creditCardMatching.completedAt': null,
-        'onboarding.creditCardMatching.error': null
+        'onboarding.creditCardMatching.error': null,
+        'onboarding.creditCardMatching.failedAccount': null
       }
     });
     
@@ -167,6 +168,190 @@ router.post('/credit-card-account', auth, async (req, res) => {
       success: false,
       error: 'Failed to add credit card account',
       message: error.message
+    });
+  }
+});
+
+/**
+ * @route   PUT /api/onboarding/credit-card-account/:accountId/credentials
+ * @desc    Repair a failed onboarding credit card account and retry its import
+ * @access  Private
+ */
+router.put('/credit-card-account/:accountId/credentials', auth, async (req, res) => {
+  const userId = req.user._id || req.user.userId;
+  const { accountId } = req.params;
+  const { username, password, card6Digits } = req.body;
+
+  try {
+    const user = await User.findById(userId);
+    const account = user?.onboarding?.creditCardSetup?.creditCardAccounts?.find(
+      candidate => candidate.accountId?.toString() === accountId
+    );
+
+    if (!account) {
+      return res.status(404).json({
+        success: false,
+        error: 'Credit card account not found in onboarding'
+      });
+    }
+    if (user.onboarding?.creditCardMatching?.failedAccount?.accountId?.toString() !== accountId) {
+      return res.status(409).json({
+        success: false,
+        error: 'Credit card account is not awaiting repair'
+      });
+    }
+    if (!username || !password) {
+      return res.status(400).json({
+        success: false,
+        error: 'Username and password are required'
+      });
+    }
+    if (account.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+      return res.status(400).json({
+        success: false,
+        error: 'Last 6 card digits must be exactly 6 digits'
+      });
+    }
+
+    await User.findByIdAndUpdate(userId, {
+      $set: {
+        'onboarding.currentStep': 'credit-card-matching',
+        'onboarding.creditCardMatching.completed': false,
+        'onboarding.creditCardMatching.completedAt': null,
+        'onboarding.creditCardMatching.error': null,
+        'onboarding.creditCardMatching.failedAccount': null,
+        'onboarding.creditCardMatching.processingAccountId': accountId
+      }
+    });
+
+    try {
+      const bankAccount = await bankAccountService.updateCredentials(
+        accountId,
+        userId,
+        { username, password, card6Digits },
+        { requireQueuedSync: true }
+      );
+
+      return res.json({
+        success: true,
+        data: {
+          accountId: bankAccount._id,
+          message: 'Credentials updated. Retrying the card import.'
+        }
+      });
+    } catch (error) {
+      const displayName = account.displayName || account.bankId || 'Credit card account';
+      const matchingError = `${displayName} still needs attention. ${error.message}`;
+
+      await User.findByIdAndUpdate(userId, {
+        $set: {
+          'onboarding.creditCardMatching.completed': true,
+          'onboarding.creditCardMatching.completedAt': new Date(),
+          'onboarding.creditCardMatching.error': matchingError,
+          'onboarding.creditCardMatching.failedAccount': {
+            accountId,
+            bankId: account.bankId,
+            displayName,
+            error: error.message
+          }
+        },
+        $unset: {
+          'onboarding.creditCardMatching.processingAccountId': ''
+        }
+      });
+
+      const queueFailed = error.code === 'SYNC_QUEUE_FAILED';
+      return res.status(queueFailed ? 503 : 400).json({
+        success: false,
+        error: queueFailed
+          ? 'Credentials updated, but the card import retry could not be started'
+          : 'Failed to update credit card credentials',
+        details: error.message
+      });
+    }
+  } catch (error) {
+    logger.error(`Failed to repair onboarding credit card account ${accountId}:`, error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to repair credit card account'
+    });
+  }
+});
+
+/**
+ * @route   DELETE /api/onboarding/credit-card-account/:accountId
+ * @desc    Remove a failed credit card account from onboarding
+ * @access  Private
+ */
+router.delete('/credit-card-account/:accountId', auth, async (req, res) => {
+  const userId = req.user._id || req.user.userId;
+  const { accountId } = req.params;
+
+  try {
+    const user = await User.findById(userId);
+    const account = user?.onboarding?.creditCardSetup?.creditCardAccounts?.find(
+      candidate => candidate.accountId?.toString() === accountId
+    );
+
+    if (!account) {
+      return res.status(404).json({
+        success: false,
+        error: 'Credit card account not found in onboarding'
+      });
+    }
+    if (user.onboarding?.creditCardMatching?.failedAccount?.accountId?.toString() !== accountId) {
+      return res.status(409).json({
+        success: false,
+        error: 'Credit card account is not awaiting removal'
+      });
+    }
+
+    const removed = await bankAccountService.delete(accountId, userId);
+    if (!removed) {
+      return res.status(404).json({
+        success: false,
+        error: 'Credit card account not found'
+      });
+    }
+
+    const matching = user.onboarding.creditCardMatching;
+    await User.findByIdAndUpdate(userId, {
+      $pull: {
+        'onboarding.creditCardSetup.creditCardAccounts': { accountId }
+      },
+      $set: {
+        'onboarding.currentStep': 'credit-card-matching',
+        'onboarding.creditCardMatching.completed': true,
+        'onboarding.creditCardMatching.completedAt': new Date(),
+        'onboarding.creditCardMatching.error': null,
+        'onboarding.creditCardMatching.failedAccount': null
+      },
+      $unset: {
+        'onboarding.creditCardMatching.processingAccountId': ''
+      }
+    });
+
+    scrapingEvents.emit('credit-card-matching:completed', {
+      userId,
+      matchingResults: {
+        coveredCount: matching.coveredPayments,
+        uncoveredCount: matching.uncoveredPayments,
+        coveragePercentage: matching.coveragePercentage
+      }
+    });
+
+    return res.json({
+      success: true,
+      data: {
+        accountId,
+        message: 'Credit card account removed.'
+      }
+    });
+  } catch (error) {
+    logger.error(`Failed to remove onboarding credit card account ${accountId}:`, error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to remove credit card account'
     });
   }
 });

--- a/backend/src/onboarding/services/onboardingEventHandlers.js
+++ b/backend/src/onboarding/services/onboardingEventHandlers.js
@@ -636,7 +636,13 @@ class OnboardingEventHandlers {
           $set: {
             'onboarding.creditCardMatching.completed': true,
             'onboarding.creditCardMatching.completedAt': completedAt,
-            'onboarding.creditCardMatching.error': matchingError
+            'onboarding.creditCardMatching.error': matchingError,
+            'onboarding.creditCardMatching.failedAccount': {
+              accountId: bankAccountId,
+              bankId: bankAccount.bankId,
+              displayName: providerName,
+              error: failureReason
+            }
           },
           $unset: {
             'onboarding.creditCardMatching.processingAccountId': ''

--- a/frontend/src/components/onboarding/chat/OnboardingChat.tsx
+++ b/frontend/src/components/onboarding/chat/OnboardingChat.tsx
@@ -65,6 +65,8 @@ export const OnboardingChat: React.FC = () => {
     error,
     addCheckingAccount,
     addCreditCardAccount,
+    repairCreditCardAccount,
+    removeCreditCardAccount,
     proceedToCreditCardSetup,
     skipCreditCards,
     completeOnboarding
@@ -74,11 +76,21 @@ export const OnboardingChat: React.FC = () => {
     () => ({
       connectCheckingAccount: addCheckingAccount,
       connectCreditCardAccount: addCreditCardAccount,
+      repairCreditCardAccount,
+      removeCreditCardAccount,
       proceedToCreditCardSetup,
       skipCreditCards,
       completeOnboarding
     }),
-    [addCheckingAccount, addCreditCardAccount, proceedToCreditCardSetup, skipCreditCards, completeOnboarding]
+    [
+      addCheckingAccount,
+      addCreditCardAccount,
+      repairCreditCardAccount,
+      removeCreditCardAccount,
+      proceedToCreditCardSetup,
+      skipCreditCards,
+      completeOnboarding
+    ]
   );
 
   const script = useMemo(() => buildScript(status), [status]);

--- a/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
+++ b/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
@@ -356,6 +356,25 @@ describe('OnboardingChat', () => {
     });
   });
 
+  it('shows details from an Axios-compatible repair error', async () => {
+    const user = userEvent.setup();
+    mockStatus = failedCard();
+    mockRepairCreditCardAccount.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        data: { details: 503 }
+      }
+    });
+    draw();
+
+    await user.click(await screen.findByTestId('fix-card-account-btn'));
+    await user.type(screen.getByTestId('repair-card-username'), 'cal-user');
+    await user.type(screen.getByTestId('repair-card-password'), 'new-password');
+    await user.click(screen.getByRole('button', { name: 'Save and retry' }));
+
+    expect(await screen.findByText('503')).toBeInTheDocument();
+  });
+
   it('confirms before removing the failed account', async () => {
     const user = userEvent.setup();
     mockStatus = failedCard();

--- a/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
+++ b/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
@@ -8,6 +8,8 @@ import { OnboardingStatus } from '../../../../services/api/onboarding';
 
 const mockAddCheckingAccount = jest.fn().mockResolvedValue({});
 const mockAddCreditCardAccount = jest.fn().mockResolvedValue({});
+const mockRepairCreditCardAccount = jest.fn().mockResolvedValue({});
+const mockRemoveCreditCardAccount = jest.fn().mockResolvedValue({});
 const mockProceedToCreditCardSetup = jest.fn().mockResolvedValue(undefined);
 const mockSkipCreditCards = jest.fn().mockResolvedValue(undefined);
 const mockCompleteOnboarding = jest.fn().mockResolvedValue(undefined);
@@ -22,6 +24,8 @@ jest.mock('../../../../hooks/useOnboarding', () => ({
     refetch: jest.fn(),
     addCheckingAccount: mockAddCheckingAccount,
     addCreditCardAccount: mockAddCreditCardAccount,
+    repairCreditCardAccount: mockRepairCreditCardAccount,
+    removeCreditCardAccount: mockRemoveCreditCardAccount,
     proceedToCreditCardSetup: mockProceedToCreditCardSetup,
     skipCreditCards: mockSkipCreditCards,
     completeOnboarding: mockCompleteOnboarding
@@ -75,6 +79,51 @@ const importing = (): OnboardingStatus => ({
     transactionsImported: 0,
     completedAt: null,
     scrapingStatus: { isActive: true, status: 'scraping', progress: 45, message: null, error: null }
+  }
+});
+
+const failedCard = (): OnboardingStatus => ({
+  ...importing(),
+  currentStep: 'credit-card-matching',
+  completedSteps: ['checking-account', 'transaction-import', 'credit-card-detection', 'credit-card-setup'],
+  transactionImport: {
+    completed: true,
+    transactionsImported: 42,
+    completedAt: '2026-01-01T00:05:00Z',
+    scrapingStatus: { isActive: false, status: 'complete', progress: 100, message: null, error: null }
+  },
+  creditCardDetection: {
+    analyzed: true,
+    analyzedAt: '2026-01-01T00:06:00Z',
+    transactionCount: 5,
+    recommendation: 'connect',
+    sampleTransactions: []
+  },
+  creditCardSetup: {
+    skipped: false,
+    skippedAt: null,
+    creditCardAccounts: [{
+      accountId: { _id: 'failed-cal', bankId: 'visaCal', displayName: 'Visa Cal Credit Cards' },
+      connectedAt: '2026-01-01T00:07:00Z',
+      bankId: 'visaCal',
+      displayName: 'Visa Cal Credit Cards'
+    }]
+  },
+  creditCardMatching: {
+    completed: true,
+    completedAt: '2026-01-01T00:08:00Z',
+    error: 'Visa Cal Credit Cards could not be imported.',
+    failedAccount: {
+      accountId: 'failed-cal',
+      bankId: 'visaCal',
+      displayName: 'Visa Cal Credit Cards',
+      error: 'The bank requires a password change.'
+    },
+    totalCreditCardPayments: 5,
+    coveredPayments: 2,
+    uncoveredPayments: 3,
+    coveragePercentage: 40,
+    matchedPayments: []
   }
 });
 
@@ -284,6 +333,42 @@ describe('OnboardingChat', () => {
     expect(screen.getByText('ending 0296')).toBeInTheDocument();
     expect(screen.getByText('ending 4940')).toBeInTheDocument();
     expect(screen.getByText(/cannot always be assigned to one card ending/)).toBeInTheDocument();
+  });
+
+  it('shows the failed account and lets the user repair it', async () => {
+    const user = userEvent.setup();
+    mockStatus = failedCard();
+    draw();
+
+    expect(await screen.findByText('Visa Cal Credit Cards needs attention')).toBeInTheDocument();
+    expect(screen.getByText('The bank requires a password change.')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('fix-card-account-btn'));
+    await user.type(await screen.findByTestId('repair-card-username'), 'cal-user');
+    await user.type(screen.getByTestId('repair-card-password'), 'new-password');
+    await user.click(screen.getByRole('button', { name: 'Save and retry' }));
+
+    await waitFor(() => {
+      expect(mockRepairCreditCardAccount).toHaveBeenCalledWith('failed-cal', {
+        username: 'cal-user',
+        password: 'new-password'
+      });
+    });
+  });
+
+  it('confirms before removing the failed account', async () => {
+    const user = userEvent.setup();
+    mockStatus = failedCard();
+    draw();
+
+    await screen.findByTestId('failed-card-account');
+    await user.click(screen.getByTestId('remove-card-account-btn'));
+    expect(screen.getByText('Remove this connection from GeriFinancial?')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('confirm-remove-card-account-btn'));
+    await waitFor(() => {
+      expect(mockRemoveCreditCardAccount).toHaveBeenCalledWith('failed-cal');
+    });
   });
 
   it('shows full progress once onboarding is complete', async () => {

--- a/frontend/src/components/onboarding/chat/cards/FailedCardAccountActions.tsx
+++ b/frontend/src/components/onboarding/chat/cards/FailedCardAccountActions.tsx
@@ -8,7 +8,7 @@ import {
   TextField,
   Typography
 } from '@mui/material';
-import { AxiosError } from 'axios';
+import axios from 'axios';
 import { OnboardingStatus } from '../../../../services/api/onboarding';
 import { ChatHandlers } from '../types';
 
@@ -19,13 +19,32 @@ interface FailedCardAccountActionsProps {
 
 type Mode = 'summary' | 'repair' | 'remove';
 
+const displayableErrorValue = (value: unknown): string | null => {
+  if (typeof value === 'string') return value.trim() || null;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return null;
+};
+
 const apiErrorMessage = (error: unknown): string => {
-  if (error instanceof AxiosError) {
-    return error.response?.data?.details
-      || error.response?.data?.error
-      || 'Failed to update the card account';
+  if (axios.isAxiosError(error)) {
+    const responseData: unknown = error.response?.data;
+    const directMessage = displayableErrorValue(responseData);
+    if (directMessage) return directMessage;
+
+    if (responseData && typeof responseData === 'object') {
+      const details = 'details' in responseData
+        ? displayableErrorValue(responseData.details)
+        : null;
+      const responseError = 'error' in responseData
+        ? displayableErrorValue(responseData.error)
+        : null;
+      return details || responseError || 'Failed to update the card account';
+    }
   }
-  return error instanceof Error ? error.message : 'Failed to update the card account';
+
+  return error instanceof Error && error.message
+    ? error.message
+    : 'Failed to update the card account';
 };
 
 export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> = ({

--- a/frontend/src/components/onboarding/chat/cards/FailedCardAccountActions.tsx
+++ b/frontend/src/components/onboarding/chat/cards/FailedCardAccountActions.tsx
@@ -1,0 +1,206 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import { AxiosError } from 'axios';
+import { OnboardingStatus } from '../../../../services/api/onboarding';
+import { ChatHandlers } from '../types';
+
+interface FailedCardAccountActionsProps {
+  account: NonNullable<OnboardingStatus['creditCardMatching']['failedAccount']>;
+  handlers: ChatHandlers;
+}
+
+type Mode = 'summary' | 'repair' | 'remove';
+
+const apiErrorMessage = (error: unknown): string => {
+  if (error instanceof AxiosError) {
+    return error.response?.data?.details
+      || error.response?.data?.error
+      || 'Failed to update the card account';
+  }
+  return error instanceof Error ? error.message : 'Failed to update the card account';
+};
+
+export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> = ({
+  account,
+  handlers
+}) => {
+  const [mode, setMode] = useState<Mode>('summary');
+  const [form, setForm] = useState({ username: '', password: '', card6Digits: '' });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const isIsracard = account.bankId === 'isracard';
+
+  useEffect(() => {
+    setMode('summary');
+    setForm({ username: '', password: '', card6Digits: '' });
+    setError('');
+  }, [account.accountId]);
+
+  const handleText = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((previous) => ({
+      ...previous,
+      [name]: name === 'card6Digits' ? value.replace(/\D/g, '').slice(0, 6) : value
+    }));
+  };
+
+  const repair = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError('');
+
+    if (!form.username || !form.password) {
+      setError('Please enter the username and new password');
+      return;
+    }
+    if (isIsracard && !/^\d{6}$/.test(form.card6Digits)) {
+      setError('Enter the last 6 digits of your Isracard');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await handlers.repairCreditCardAccount(account.accountId, {
+        username: form.username,
+        password: form.password,
+        ...(isIsracard && { card6Digits: form.card6Digits })
+      });
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    setBusy(true);
+    setError('');
+    try {
+      await handlers.removeCreditCardAccount(account.accountId);
+    } catch (err) {
+      setError(apiErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Box sx={{ mb: 2 }} data-testid="failed-card-account">
+      <Alert severity="error">
+        <AlertTitle>{account.displayName} needs attention</AlertTitle>
+        {account.error}
+      </Alert>
+
+      {mode === 'summary' && (
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mt: 1.5 }}>
+          <Button
+            variant="contained"
+            onClick={() => setMode('repair')}
+            data-testid="fix-card-account-btn"
+          >
+            Fix account
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => setMode('remove')}
+            data-testid="remove-card-account-btn"
+          >
+            Remove account
+          </Button>
+        </Stack>
+      )}
+
+      {mode === 'repair' && (
+        <Box component="form" onSubmit={repair} sx={{ mt: 1.5 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Enter the credentials for {account.displayName}. They will be validated before the import retries.
+          </Typography>
+          <TextField
+            fullWidth
+            margin="dense"
+            size="small"
+            label={isIsracard ? 'ID Number' : 'Username'}
+            name="username"
+            value={form.username}
+            onChange={handleText}
+            disabled={busy}
+            required
+            inputProps={{ 'data-testid': 'repair-card-username' }}
+          />
+          {isIsracard && (
+            <TextField
+              fullWidth
+              margin="dense"
+              size="small"
+              label="Last 6 card digits"
+              name="card6Digits"
+              value={form.card6Digits}
+              onChange={handleText}
+              disabled={busy}
+              required
+              inputProps={{
+                inputMode: 'numeric',
+                pattern: '[0-9]{6}',
+                maxLength: 6,
+                'data-testid': 'repair-card6-digits'
+              }}
+            />
+          )}
+          <TextField
+            fullWidth
+            margin="dense"
+            size="small"
+            label="New password"
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={handleText}
+            disabled={busy}
+            required
+            inputProps={{ 'data-testid': 'repair-card-password' }}
+          />
+          {error && <Alert severity="error" sx={{ mt: 1 }}>{error}</Alert>}
+          <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+            <Button type="submit" variant="contained" disabled={busy}>
+              {busy ? 'Checking...' : 'Save and retry'}
+            </Button>
+            <Button onClick={() => setMode('summary')} disabled={busy}>
+              Cancel
+            </Button>
+          </Stack>
+        </Box>
+      )}
+
+      {mode === 'remove' && (
+        <Box sx={{ mt: 1.5 }}>
+          <Typography variant="body2">
+            Remove this connection from GeriFinancial?
+          </Typography>
+          {error && <Alert severity="error" sx={{ mt: 1 }}>{error}</Alert>}
+          <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={remove}
+              disabled={busy}
+              data-testid="confirm-remove-card-account-btn"
+            >
+              {busy ? 'Removing...' : 'Remove account'}
+            </Button>
+            <Button onClick={() => setMode('summary')} disabled={busy}>
+              Cancel
+            </Button>
+          </Stack>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
@@ -5,6 +5,7 @@ import { CardShell } from '../CardShell';
 import { CardProps } from '../types';
 import { CREDIT_CARD_PROVIDERS } from '../../../../constants/banks';
 import { formatCurrencyDisplay } from '../../../../utils/formatters';
+import { FailedCardAccountActions } from './FailedCardAccountActions';
 
 const providerName = (provider: string): string =>
   CREDIT_CARD_PROVIDERS.find((candidate) => candidate.id === provider)?.name || provider;
@@ -28,6 +29,7 @@ export const MatchingReviewCard: React.FC<CardProps> = ({ status, handlers }) =>
   const matching = status.creditCardMatching;
   const cards = matching?.connectedCreditCards || [];
   const matchedPayments = matching?.matchedPayments || [];
+  const failedAccount = matching?.failedAccount;
   const percentage = Math.round(matching?.coveragePercentage || 0);
 
   const run = async (action: 'more' | 'finish') => {
@@ -41,6 +43,10 @@ export const MatchingReviewCard: React.FC<CardProps> = ({ status, handlers }) =>
 
   return (
     <CardShell testId="matching-review">
+      {failedAccount && (
+        <FailedCardAccountActions account={failedAccount} handlers={handlers} />
+      )}
+
       {(matching?.totalCreditCardPayments ?? 0) > 0 && (
         <Box sx={{ mb: 2 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CheckingAccountCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CheckingAccountCard.test.tsx
@@ -8,6 +8,8 @@ import { ChatHandlers } from '../../types';
 const handlers: ChatHandlers = {
   connectCheckingAccount: jest.fn().mockResolvedValue(undefined),
   connectCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  repairCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  removeCreditCardAccount: jest.fn().mockResolvedValue(undefined),
   proceedToCreditCardSetup: jest.fn().mockResolvedValue(undefined),
   skipCreditCards: jest.fn().mockResolvedValue(undefined),
   completeOnboarding: jest.fn().mockResolvedValue(undefined)

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardChoiceCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardChoiceCard.test.tsx
@@ -7,6 +7,8 @@ import { ChatHandlers } from '../../types';
 const handlers: ChatHandlers = {
   connectCheckingAccount: jest.fn().mockResolvedValue(undefined),
   connectCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  repairCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  removeCreditCardAccount: jest.fn().mockResolvedValue(undefined),
   proceedToCreditCardSetup: jest.fn().mockResolvedValue(undefined),
   skipCreditCards: jest.fn().mockResolvedValue(undefined),
   completeOnboarding: jest.fn().mockResolvedValue(undefined)

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
@@ -8,6 +8,8 @@ import { ChatHandlers } from '../../types';
 const handlers: ChatHandlers = {
   connectCheckingAccount: jest.fn().mockResolvedValue(undefined),
   connectCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  repairCreditCardAccount: jest.fn().mockResolvedValue(undefined),
+  removeCreditCardAccount: jest.fn().mockResolvedValue(undefined),
   proceedToCreditCardSetup: jest.fn().mockResolvedValue(undefined),
   skipCreditCards: jest.fn().mockResolvedValue(undefined),
   completeOnboarding: jest.fn().mockResolvedValue(undefined)

--- a/frontend/src/components/onboarding/chat/types.ts
+++ b/frontend/src/components/onboarding/chat/types.ts
@@ -40,6 +40,11 @@ export interface ChatHandlers {
     credentials: { username: string; password: string; card6Digits?: string },
     displayName: string
   ) => Promise<unknown>;
+  repairCreditCardAccount: (
+    accountId: string,
+    credentials: { username: string; password: string; card6Digits?: string }
+  ) => Promise<unknown>;
+  removeCreditCardAccount: (accountId: string) => Promise<unknown>;
   proceedToCreditCardSetup: () => Promise<void>;
   skipCreditCards: () => Promise<void>;
   completeOnboarding: () => Promise<void>;

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -9,6 +9,11 @@ interface UseOnboardingResult {
   refetch: () => Promise<OnboardingStatus>;
   addCheckingAccount: (bankId: string, credentials: any, displayName?: string) => Promise<any>;
   addCreditCardAccount: (bankId: string, credentials: any, displayName?: string) => Promise<any>;
+  repairCreditCardAccount: (
+    accountId: string,
+    credentials: { username: string; password: string; card6Digits?: string }
+  ) => Promise<any>;
+  removeCreditCardAccount: (accountId: string) => Promise<any>;
   proceedToCreditCardSetup: () => Promise<void>;
   skipCreditCards: () => Promise<void>;
   completeOnboarding: () => Promise<void>;
@@ -64,6 +69,34 @@ export const useOnboarding = (): UseOnboardingResult => {
       case 'onboarding:credit-card-matching':
         await fetchStatus();
         break;
+    }
+  }, [fetchStatus]);
+
+  const repairCreditCardAccount = useCallback(async (
+    accountId: string,
+    credentials: { username: string; password: string; card6Digits?: string }
+  ) => {
+    try {
+      setError(null);
+      const result = await onboardingApi.repairCreditCardAccount(accountId, credentials);
+      await fetchStatus();
+      return result;
+    } catch (err) {
+      await fetchStatus();
+      setError(err as Error);
+      throw err;
+    }
+  }, [fetchStatus]);
+
+  const removeCreditCardAccount = useCallback(async (accountId: string) => {
+    try {
+      setError(null);
+      const result = await onboardingApi.removeCreditCardAccount(accountId);
+      await fetchStatus();
+      return result;
+    } catch (err) {
+      setError(err as Error);
+      throw err;
     }
   }, [fetchStatus]);
 
@@ -169,6 +202,8 @@ export const useOnboarding = (): UseOnboardingResult => {
     refetch: fetchStatus,
     addCheckingAccount,
     addCreditCardAccount,
+    repairCreditCardAccount,
+    removeCreditCardAccount,
     proceedToCreditCardSetup,
     skipCreditCards,
     completeOnboarding

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -72,6 +72,15 @@ export const useOnboarding = (): UseOnboardingResult => {
     }
   }, [fetchStatus]);
 
+  const refetchAfterActionFailure = useCallback(async () => {
+    try {
+      await fetchStatus();
+    } catch (refreshError) {
+      // fetchStatus already exposes this error through the hook state.
+      console.error('[useOnboarding] Failed to refresh after an onboarding action:', refreshError);
+    }
+  }, [fetchStatus]);
+
   const repairCreditCardAccount = useCallback(async (
     accountId: string,
     credentials: { username: string; password: string; card6Digits?: string }
@@ -82,11 +91,10 @@ export const useOnboarding = (): UseOnboardingResult => {
       await fetchStatus();
       return result;
     } catch (err) {
-      await fetchStatus();
-      setError(err as Error);
+      await refetchAfterActionFailure();
       throw err;
     }
-  }, [fetchStatus]);
+  }, [fetchStatus, refetchAfterActionFailure]);
 
   const removeCreditCardAccount = useCallback(async (accountId: string) => {
     try {
@@ -95,10 +103,10 @@ export const useOnboarding = (): UseOnboardingResult => {
       await fetchStatus();
       return result;
     } catch (err) {
-      setError(err as Error);
+      await refetchAfterActionFailure();
       throw err;
     }
-  }, [fetchStatus]);
+  }, [fetchStatus, refetchAfterActionFailure]);
 
   // Connect to SSE for real-time updates
   useSSE(handleSSEEvent, { autoConnect: true });

--- a/frontend/src/services/api/onboarding.ts
+++ b/frontend/src/services/api/onboarding.ts
@@ -66,6 +66,12 @@ export interface OnboardingStatus {
     completed: boolean;
     completedAt: string | null;
     error?: string | null;
+    failedAccount?: {
+      accountId: string;
+      bankId: string;
+      displayName: string;
+      error: string;
+    } | null;
     totalCreditCardPayments: number;
     coveredPayments: number;
     uncoveredPayments: number;
@@ -246,6 +252,22 @@ export const onboardingApi = {
       credentials,
       displayName
     });
+    return response.data.data;
+  },
+
+  repairCreditCardAccount: async (
+    accountId: string,
+    credentials: { username: string; password: string; card6Digits?: string }
+  ) => {
+    const response = await api.put(
+      `/onboarding/credit-card-account/${accountId}/credentials`,
+      credentials
+    );
+    return response.data.data;
+  },
+
+  removeCreditCardAccount: async (accountId: string) => {
+    const response = await api.delete(`/onboarding/credit-card-account/${accountId}`);
     return response.data.data;
   },
 


### PR DESCRIPTION
## What Changed
- Record the exact card account when an onboarding import fails.
- Show the failed provider and reason in chat with **Fix account** and **Remove account** actions.
- Validate replacement credentials, automatically retry the import, and restore the prior matching result if validation or queueing fails.
- Remove a failed connection without discarding the existing card-payment coverage result.

## Why
A failed second CAL connection was visible only as a generic matching error. Users could not tell which connection needed attention or recover without leaving onboarding.

## Impact Analysis
- Credential updates continue through the existing encrypted credential service.
- Repair and removal are restricted to the authenticated user's account currently marked as failed.
- No dependency or database migration changes; existing users receive the nullable onboarding field through the Mongoose schema.

## Quality Gates
- Added backend coverage for failure persistence, credential repair, removal, and retry queue failures.
- Added frontend coverage for failed-account repair and confirmed removal.