### PR TITLE
bugfix(banking): initialize scraper credential checks

### DIFF
--- a/backend/src/banking/services/__tests__/bankScraperService.test.js
+++ b/backend/src/banking/services/__tests__/bankScraperService.test.js
@@ -21,6 +21,10 @@ describe('BankScraperService', () => {
     })
   };
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('login', () => {
     it('should successfully login with valid credentials', async () => {
       const scraper = await bankScraperService.login(mockBankAccount);
@@ -68,6 +72,44 @@ describe('BankScraperService', () => {
         .rejects
         .toThrow('Login failed: Invalid bank credentials');
     });
+
+    it('initializes the scraper before logging in', async () => {
+      const scraper = {
+        initialize: jest.fn().mockResolvedValue(undefined),
+        login: jest.fn().mockResolvedValue({ success: true })
+      };
+      jest.spyOn(bankScraperService, 'createScraper').mockReturnValue(scraper);
+
+      await bankScraperService.login(mockBankAccount);
+
+      expect(scraper.initialize).toHaveBeenCalledTimes(1);
+      expect(scraper.login).toHaveBeenCalledTimes(1);
+      expect(scraper.initialize.mock.invocationCallOrder[0])
+        .toBeLessThan(scraper.login.mock.invocationCallOrder[0]);
+    });
+
+    it('rejects an unsuccessful scraper login result', async () => {
+      const originalMaxRetries = bankScraperService.MAX_RETRIES;
+      const scraper = {
+        initialize: jest.fn().mockResolvedValue(undefined),
+        login: jest.fn().mockResolvedValue({
+          success: false,
+          errorType: 'CHANGE_PASSWORD'
+        }),
+        terminate: jest.fn().mockResolvedValue(undefined)
+      };
+      jest.spyOn(bankScraperService, 'createScraper').mockReturnValue(scraper);
+      bankScraperService.MAX_RETRIES = 1;
+
+      try {
+        await expect(bankScraperService.login(mockBankAccount)).rejects.toThrow(
+          'Login failed: The bank requires a password change'
+        );
+        expect(scraper.terminate).toHaveBeenCalledWith(false);
+      } finally {
+        bankScraperService.MAX_RETRIES = originalMaxRetries;
+      }
+    });
   });
 
   // REMOVED: scrapeTransactions tests
@@ -81,6 +123,22 @@ describe('BankScraperService', () => {
         password: 'bankpass123'
       });
       expect(result).toBe(true);
+    });
+
+    it('closes the temporary scraper after validation', async () => {
+      const scraper = {
+        initialize: jest.fn().mockResolvedValue(undefined),
+        login: jest.fn().mockResolvedValue({ success: true }),
+        terminate: jest.fn().mockResolvedValue(undefined)
+      };
+      jest.spyOn(bankScraperService, 'createScraper').mockReturnValue(scraper);
+
+      await bankScraperService.validateCredentials('hapoalim', {
+        username: 'testuser',
+        password: 'bankpass123'
+      });
+
+      expect(scraper.terminate).toHaveBeenCalledWith(true);
     });
 
     it('should reject invalid credentials', async () => {

--- a/backend/src/banking/services/bankScraperService.js
+++ b/backend/src/banking/services/bankScraperService.js
@@ -6,6 +6,7 @@ const { createScraper } = scraperModule;
 const logger = require('../../shared/utils/logger');
 const { BankAccount } = require('../models');
 const { resolveStartDate } = require('../utils/scraperDates');
+const { getScraperErrorMessage } = require('../utils/scraperErrors');
 
 
 class BankScraperService {
@@ -86,17 +87,19 @@ class BankScraperService {
   }
 
   async login(bankAccount, options = {}) {
-    const scraper = this.createScraper(bankAccount, options);
     const { credentials } = await bankAccount.getScraperOptions();
     let attempts = 0;
     let error = null;
 
     while (attempts < this.MAX_RETRIES) {
+      const scraper = this.createScraper(bankAccount, options);
+
       try {
+        await scraper.initialize();
         const loginResult = await scraper.login(credentials);
 
-        if (!loginResult) {
-          throw new Error('Login failed - invalid credentials');
+        if (loginResult !== true && loginResult?.success !== true) {
+          throw new Error(getScraperErrorMessage(loginResult));
         }
 
         logger.info(`Successfully logged in to bank account ${bankAccount._id}`);
@@ -104,6 +107,7 @@ class BankScraperService {
       } catch (err) {
         error = err;
         attempts++;
+        await this.terminateScraper(scraper, false);
         
         if (attempts < this.MAX_RETRIES) {
           logger.info(`Login attempt ${attempts} failed for bank account ${bankAccount._id}, retrying in ${this.RETRY_DELAY}ms...`);
@@ -113,6 +117,18 @@ class BankScraperService {
     }
 
     this.handleScraperError(error, 'Login', bankAccount._id);
+  }
+
+  async terminateScraper(scraper, success) {
+    if (typeof scraper?.terminate !== 'function') {
+      return;
+    }
+
+    try {
+      await scraper.terminate(success);
+    } catch (error) {
+      logger.warn(`Failed to close scraper after login validation: ${error.message}`);
+    }
   }
 
   // REMOVED: Old comprehensive scrapeTransactions method
@@ -424,21 +440,27 @@ class BankScraperService {
       })
     };
     
+    let scraper;
     try {
-      await this.login(tempAccount, { verbose: true });
+      scraper = await this.login(tempAccount, { verbose: true });
       return true;
-    } catch (error) {
-      throw error; // Let the caller handle the error
+    } finally {
+      if (scraper) {
+        await this.terminateScraper(scraper, true);
+      }
     }
   }
 
   async testConnection(bankAccount) {
+    let scraper;
     try {
-      await this.login(bankAccount);
+      scraper = await this.login(bankAccount);
       logger.info(`Connection test successful for bank account ${bankAccount._id}`);
       return true;
-    } catch (error) {
-      throw error; // Let the caller handle the error
+    } finally {
+      if (scraper) {
+        await this.terminateScraper(scraper, true);
+      }
     }
   }
 

--- a/backend/src/banking/services/bankScraperService.js
+++ b/backend/src/banking/services/bankScraperService.js
@@ -127,7 +127,7 @@ class BankScraperService {
     try {
       await scraper.terminate(success);
     } catch (error) {
-      logger.warn(`Failed to close scraper after login validation: ${error.message}`);
+      logger.warn(`Failed to terminate scraper cleanly: ${error.message}`);
     }
   }
 

--- a/backend/src/banking/services/sync-strategies/IsraeliScraperSyncStrategy.js
+++ b/backend/src/banking/services/sync-strategies/IsraeliScraperSyncStrategy.js
@@ -1,37 +1,6 @@
 const logger = require('../../../shared/utils/logger');
 const BaseSyncStrategy = require('./BaseSyncStrategy');
-
-const SCRAPER_ERROR_MESSAGES = {
-  TWO_FACTOR_RETRIEVER_MISSING: 'Two-factor authentication is required for this account',
-  INVALID_PASSWORD: 'Invalid bank credentials',
-  CHANGE_PASSWORD: 'The bank requires a password change. Sign in to the bank website, change the password, then update the saved credentials',
-  TIMEOUT: 'The bank website took too long to respond',
-  ACCOUNT_BLOCKED: 'The bank account is blocked. Contact the bank before retrying',
-  GENERIC: 'The bank scraper encountered an unexpected error',
-  GENERAL_ERROR: 'The bank website returned an unexpected login error'
-};
-
-function getScraperErrorMessage(scrapingResult) {
-  const errorMessage = typeof scrapingResult?.errorMessage === 'string'
-    ? scrapingResult.errorMessage.trim()
-    : '';
-
-  if (errorMessage) {
-    return errorMessage;
-  }
-
-  const errorType = typeof scrapingResult?.errorType === 'string'
-    ? scrapingResult.errorType.trim()
-    : '';
-
-  if (Object.prototype.hasOwnProperty.call(SCRAPER_ERROR_MESSAGES, errorType)) {
-    return SCRAPER_ERROR_MESSAGES[errorType];
-  }
-
-  return errorType
-    ? `Scraper failed with error type ${errorType}`
-    : 'Scraper failed without error details';
-}
+const { getScraperErrorMessage } = require('../../utils/scraperErrors');
 
 /**
  * Sync strategy for banks that use the israeli-bank-scrapers library.

--- a/backend/src/banking/utils/scraperErrors.js
+++ b/backend/src/banking/utils/scraperErrors.js
@@ -1,0 +1,35 @@
+const SCRAPER_ERROR_MESSAGES = {
+  TWO_FACTOR_RETRIEVER_MISSING: 'Two-factor authentication is required for this account',
+  INVALID_PASSWORD: 'Invalid bank credentials',
+  CHANGE_PASSWORD: 'The bank requires a password change. Sign in to the bank website, change the password, then update the saved credentials',
+  TIMEOUT: 'The bank website took too long to respond',
+  ACCOUNT_BLOCKED: 'The bank account is blocked. Contact the bank before retrying',
+  GENERIC: 'The bank scraper encountered an unexpected error',
+  GENERAL_ERROR: 'The bank website returned an unexpected login error'
+};
+
+function getScraperErrorMessage(scrapingResult) {
+  const errorMessage = typeof scrapingResult?.errorMessage === 'string'
+    ? scrapingResult.errorMessage.trim()
+    : '';
+
+  if (errorMessage) {
+    return errorMessage;
+  }
+
+  const errorType = typeof scrapingResult?.errorType === 'string'
+    ? scrapingResult.errorType.trim()
+    : '';
+
+  if (Object.prototype.hasOwnProperty.call(SCRAPER_ERROR_MESSAGES, errorType)) {
+    return SCRAPER_ERROR_MESSAGES[errorType];
+  }
+
+  return errorType
+    ? `Scraper failed with error type ${errorType}`
+    : 'Scraper failed without error details';
+}
+
+module.exports = {
+  getScraperErrorMessage
+};


### PR DESCRIPTION
## What Changed
- Initialize browser-backed scrapers before credential login validation.
- Treat `{ success: false }` login responses as failures and reuse the existing actionable scraper error messages.
- Close failed browser attempts before retrying with a fresh scraper, and close successful temporary validation sessions.
- Add coverage for initialization order, unsuccessful login results, password-change errors, and browser cleanup.

## Why
Repairing the failed card connection called `scraper.login()` without initialization, leaving the scraper page undefined and producing `Cannot read properties of undefined (reading 'setRequestInterception')`. The same wrapper also treated non-throwing failed login results as successful.

## Impact Analysis
- Credential validation now uses the browser lifecycle expected by `israeli-bank-scrapers`.
- Failed attempts no longer leak browser processes or reuse pages with interception handlers already installed.
- No dependency, schema, or configuration changes.

## Quality Gates
- Full backend and frontend test suites passed.
- Frontend lint, TypeScript checks, and production build passed.

## Deployment Considerations
- Deploy before retrying the failed card account credentials.
- No migration or manual configuration is required.