### PR TITLE
enhance(onboarding): show matched card endings

### DIFF
--- a/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
+++ b/frontend/src/components/onboarding/chat/__tests__/OnboardingChat.test.tsx
@@ -319,6 +319,22 @@ describe('OnboardingChat', () => {
           },
           matchedMonth: '2026-08',
           matchConfidence: 91
+        }, {
+          payment: {
+            id: 'payment-2',
+            date: '2026-07-10T00:00:00.000Z',
+            description: 'Card payment',
+            amount: 3978.23
+          },
+          matchedCreditCard: {
+            id: null,
+            displayName: 'Visa Cal Credit Cards',
+            cardNumber: null,
+            lastFourDigits: null,
+            provider: 'visaCal'
+          },
+          matchedMonth: '2026-07',
+          matchConfidence: 100
         }],
         connectedCreditCards: [
           { id: 'card-1', displayName: '0296', provider: 'visaCal' },
@@ -330,6 +346,8 @@ describe('OnboardingChat', () => {
 
     expect(await screen.findByText('Matched checking-account payments')).toBeInTheDocument();
     expect(screen.getByText(/34,208\.45/)).toBeInTheDocument();
+    expect(screen.getByText(/3,978\.23/)).toBeInTheDocument();
+    expect(screen.getByText('Matched to Visa Cal · ending 0296')).toBeInTheDocument();
     expect(screen.getByText('Matched to Visa Cal')).toBeInTheDocument();
     expect(screen.getByText('Connected cards (last 4 digits)')).toBeInTheDocument();
     expect(screen.getByText('ending 0296')).toBeInTheDocument();

--- a/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/MatchingReviewCard.tsx
@@ -19,6 +19,16 @@ const PAYMENT_DATE_FORMATTER = new Intl.DateTimeFormat('en-IL', {
 
 const formatPaymentDate = (date: string): string => PAYMENT_DATE_FORMATTER.format(new Date(date));
 
+const matchedCardEnding = (
+  matchedCard: CardProps['status']['creditCardMatching']['matchedPayments'][number]['matchedCreditCard']
+): string | null => {
+  for (const value of [matchedCard.lastFourDigits, matchedCard.cardNumber]) {
+    const ending = value?.match(/\d{4}$/)?.[0];
+    if (ending) return ending;
+  }
+  return null;
+};
+
 /**
  * Shown once the card statements have been matched against the payments in the
  * checking account. Finishing is always allowed because a provider debit can
@@ -72,16 +82,20 @@ export const MatchingReviewCard: React.FC<CardProps> = ({ status, handlers }) =>
             Matched checking-account payments
           </Typography>
           <Stack spacing={1}>
-            {matchedPayments.map((match) => (
-              <Box key={match.payment.id}>
-                <Typography variant="body2">
-                  {formatPaymentDate(match.payment.date)} · {formatCurrencyDisplay(match.payment.amount)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Matched to {providerName(match.matchedCreditCard.provider)}
-                </Typography>
-              </Box>
-            ))}
+            {matchedPayments.map((match) => {
+              const ending = matchedCardEnding(match.matchedCreditCard);
+              return (
+                <Box key={match.payment.id}>
+                  <Typography variant="body2">
+                    {formatPaymentDate(match.payment.date)} · {formatCurrencyDisplay(match.payment.amount)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Matched to {providerName(match.matchedCreditCard.provider)}
+                    {ending && ` · ending ${ending}`}
+                  </Typography>
+                </Box>
+              );
+            })}
           </Stack>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
             A provider debit can combine several physical cards, so it cannot always be assigned to one card ending.

--- a/frontend/src/services/api/onboarding.ts
+++ b/frontend/src/services/api/onboarding.ts
@@ -84,10 +84,10 @@ export interface OnboardingStatus {
         amount: number;
       };
       matchedCreditCard: {
-        id: string;
+        id: string | null;
         displayName: string;
-        cardNumber: string;
-        lastFourDigits: string;
+        cardNumber: string | null;
+        lastFourDigits: string | null;
         provider: string;
       };
       matchedMonth: string;


### PR DESCRIPTION
## What Changed
- Shows the matched physical-card ending beside provider names when the backend identifies a specific card.
- Falls back to the provider-only label when a combined provider debit cannot be assigned to one card.
- Allows nullable card IDs and endings in the onboarding API type to reflect provider-level matches accurately.

## Why
The matching API already returns card ending details, but the onboarding review currently discards them. Users with multiple cards from the same provider cannot tell which card covered a checking-account payment.

## Impact Analysis
- Frontend-only display change; no dependency, storage, or configuration changes.
- Does not infer an ending for ambiguous provider-level matches.

## Quality Gates
- Covers both specific-card and provider-only matches in onboarding chat tests.
- Backend tests and all frontend test, lint, type-check, and build gates pass.

## Deployment Considerations
No migration or configuration changes are required.