### PR TITLE
fix(cards): reject future debit-cycle matches

### DIFF
--- a/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
+++ b/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
@@ -201,6 +201,43 @@ describe('CreditCardDetectionService', () => {
       );
     });
 
+    it('does not match a payment to a future provider debit cycle', async () => {
+      const visaCal = bankAccount('visaCal', 'Visa Cal');
+      const visaCalCard = card(visaCal, '0296');
+      const results = await creditCardDetectionService.matchPaymentsToCards(
+        [
+          payment('כרטיסי אשראי-י', 34208.45),
+          payment('ל.מאסטרקרד(יש)', 3978.23)
+        ],
+        [{
+          creditCards: [visaCalCard],
+          provider: 'visaCal',
+          displayName: 'Visa Cal',
+          debitDate: new Date('2026-08-10T00:00:00.000Z'),
+          debitDateKey: '2026-08-10',
+          totalSpent: 31131.79,
+          transactionCount: 83
+        }, {
+          creditCards: [visaCalCard],
+          provider: 'visaCal',
+          displayName: 'Visa Cal',
+          debitDate: new Date('2026-09-10T00:00:00.000Z'),
+          debitDateKey: '2026-09-10',
+          totalSpent: 3869.73,
+          transactionCount: 10
+        }]
+      );
+
+      expect(results.coveredCount).toBe(1);
+      expect(results.matchedPayments[0].payment.amount).toBe(34208.45);
+      expect(results.uncoveredPayments).toEqual([
+        expect.objectContaining({
+          description: 'ל.מאסטרקרד(יש)',
+          amount: -3978.23
+        })
+      ]);
+    });
+
     it('does not match an explicitly named provider to another provider', async () => {
       const visaCal = bankAccount('visaCal', 'Visa Cal');
       const results = await creditCardDetectionService.matchPaymentsToCards(

--- a/backend/src/banking/services/creditCardDetectionService.js
+++ b/backend/src/banking/services/creditCardDetectionService.js
@@ -610,12 +610,12 @@ class CreditCardDetectionService {
           if (paymentProvider && debitTotal.provider !== paymentProvider) continue;
 
           const exactDebitDate = paymentDateKey === debitTotal.debitDateKey;
+          const debitDateAfterPayment = debitTotal.debitDateKey > paymentDateKey;
           const amountDiff = Math.abs(paymentAmount - debitTotal.totalSpent);
           const amountDiffPercentage = amountDiff / paymentAmount;
-          const monthDiff = Math.abs(
-            monthIndex(debitTotal.debitDateKey) - monthIndex(paymentDateKey)
-          );
+          const monthDiff = monthIndex(paymentDateKey) - monthIndex(debitTotal.debitDateKey);
 
+          if (debitDateAfterPayment) continue;
           if (!exactDebitDate && (monthDiff > 1 || amountDiffPercentage > 0.05)) continue;
 
           possibleMatches.push({


### PR DESCRIPTION
## What Changed
- Rejects credit-card debit totals dated after the checking-account payment being matched.
- Keeps exact debit-date matching and prior-cycle amount matching unchanged.
- Adds a production-shaped regression covering the two 10 Aug payments and the future 10 Sep CAL cycle.

## Why
The `3,978.23` payment from 10 Aug was incorrectly matched to card ending `0296` because its amount was within 5% of that card's future 10 Sep debit total (`3,869.73`). A payment cannot settle a later billing cycle.

## Impact Analysis
- Corrects card attribution and coverage calculations for future-cycle candidates.
- Existing stored onboarding results must be recomputed after deployment.
- No dependency, schema, or configuration changes.

## Quality Gates
- Added regression coverage for the exact production failure.
- Verified the corrected matcher against production data: only `34,208.45` matches `0296`; `3,978.23` remains uncovered.
- Backend tests and all frontend test, lint, type-check, and build gates pass.

## Deployment Considerations
After deployment, refresh the affected onboarding matching result so stale persisted matches use the corrected algorithm.