### PR TITLE
fix(onboarding): defer card credential validation

### DIFF
--- a/backend/src/banking/services/__tests__/bankAccountService.test.js
+++ b/backend/src/banking/services/__tests__/bankAccountService.test.js
@@ -368,6 +368,39 @@ describe('BankAccountService', () => {
         password: 'new-password'
       });
     });
+
+    it('requires the queued retry whenever credential validation is deferred', async () => {
+      const account = await BankAccount.create({
+        userId,
+        bankId: mockAccountData.bankId,
+        name: mockAccountData.name,
+        credentials: {
+          username: mockAccountData.username,
+          password: mockAccountData.password
+        },
+        status: 'error'
+      });
+      queuedDataSyncService.queueBankAccountSync.mockRejectedValueOnce(new Error('Queue unavailable'));
+
+      await expect(bankAccountService.updateCredentials(
+        account._id,
+        userId,
+        {
+          username: 'new-user',
+          password: 'new-password'
+        },
+        { deferCredentialValidation: true }
+      )).rejects.toMatchObject({
+        code: 'SYNC_QUEUE_FAILED',
+        message: expect.stringContaining('Queue unavailable')
+      });
+
+      expect(bankScraperService.validateCredentials).not.toHaveBeenCalled();
+      const updatedAccount = await BankAccount.findById(account._id);
+      expect(updatedAccount.status).toBe('error');
+      expect(updatedAccount.lastError.message)
+        .toBe('Credentials were updated, but the automatic import retry could not be started');
+    });
   });
 
   describe('recoverMissingTransactions', () => {

--- a/backend/src/banking/services/__tests__/bankAccountService.test.js
+++ b/backend/src/banking/services/__tests__/bankAccountService.test.js
@@ -103,6 +103,20 @@ describe('BankAccountService', () => {
       expect(eventListeners.accountCreated).not.toHaveBeenCalled();
     });
 
+    it('can defer credential validation to the initial background scrape', async () => {
+      const account = await bankAccountService.create(
+        userId,
+        mockAccountData,
+        { deferCredentialValidation: true }
+      );
+
+      expect(bankScraperService.validateCredentials).not.toHaveBeenCalled();
+      expect(account.status).toBe('active');
+      expect(eventListeners.accountCreated).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: account._id })
+      );
+    });
+
     it('should validate and store Isracard last-six credentials', async () => {
       bankScraperService.validateCredentials.mockResolvedValueOnce(true);
 
@@ -282,6 +296,42 @@ describe('BankAccountService', () => {
   });
 
   describe('updateCredentials', () => {
+    it('can defer validation and queue the credential retry immediately', async () => {
+      const account = await BankAccount.create({
+        userId,
+        bankId: mockAccountData.bankId,
+        name: mockAccountData.name,
+        credentials: {
+          username: mockAccountData.username,
+          password: mockAccountData.password
+        },
+        status: 'error'
+      });
+      queuedDataSyncService.queueBankAccountSync.mockResolvedValueOnce();
+
+      const updatedAccount = await bankAccountService.updateCredentials(
+        account._id,
+        userId,
+        {
+          username: 'new-user',
+          password: 'new-password'
+        },
+        {
+          requireQueuedSync: true,
+          deferCredentialValidation: true
+        }
+      );
+
+      expect(bankScraperService.validateCredentials).not.toHaveBeenCalled();
+      expect(queuedDataSyncService.queueBankAccountSync)
+        .toHaveBeenCalledWith(account._id, { priority: 'high' });
+      expect(updatedAccount.status).toBe('active');
+      expect((await updatedAccount.getScraperOptions()).credentials).toEqual({
+        username: 'new-user',
+        password: 'new-password'
+      });
+    });
+
     it('surfaces a required retry queue failure without leaving the account active', async () => {
       const account = await BankAccount.create({
         userId,

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -156,6 +156,8 @@ class BankAccountService {
     if (!bankAccount) {
       throw new Error('Bank account not found');
     }
+    // A deferred check makes the queued import the only validation path.
+    const queuedSyncRequired = requireQueuedSync || deferCredentialValidation;
 
     if (bankAccount.bankId === 'mercury') {
       // Mercury uses API token — no scraper validation
@@ -201,7 +203,7 @@ class BankAccountService {
       logger.info(`Queued scraping job for account ${bankAccount.name} after credential update`);
     } catch (error) {
       logger.error(`Failed to queue scraping after credential update for account ${bankAccount.name}:`, error);
-      if (requireQueuedSync) {
+      if (queuedSyncRequired) {
         bankAccount.status = 'error';
         bankAccount.lastError = {
           message: 'Credentials were updated, but the automatic import retry could not be started',

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -31,7 +31,7 @@ class BankAccountService {
     flexToken,
     queryId,
     phoneOrEmail
-  }) {
+  }, { deferCredentialValidation = false } = {}) {
     name = normalizeAccountName(name);
     const duplicateName = await BankAccount.exists({
       userId,
@@ -57,10 +57,12 @@ class BankAccountService {
       if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
         throw new Error('Last 6 card digits must be exactly 6 digits');
       }
-      await bankScraperService.validateCredentials(
-        bankId,
-        buildScraperCredentials(bankId, { username, password, card6Digits })
-      );
+      if (!deferCredentialValidation) {
+        await bankScraperService.validateCredentials(
+          bankId,
+          buildScraperCredentials(bankId, { username, password, card6Digits })
+        );
+      }
       credentials = {
         username,
         password,
@@ -144,7 +146,10 @@ class BankAccountService {
     apiToken,
     flexToken,
     queryId
-  }, { requireQueuedSync = false } = {}) {
+  }, {
+    requireQueuedSync = false,
+    deferCredentialValidation = false
+  } = {}) {
     const bankAccount = await BankAccount.findOne({ _id: accountId, userId });
     if (!bankAccount) {
       throw new Error('Bank account not found');
@@ -161,10 +166,12 @@ class BankAccountService {
       if (bankAccount.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
         throw new Error('Last 6 card digits must be exactly 6 digits');
       }
-      await bankScraperService.validateCredentials(
-        bankAccount.bankId,
-        buildScraperCredentials(bankAccount.bankId, { username, password, card6Digits })
-      );
+      if (!deferCredentialValidation) {
+        await bankScraperService.validateCredentials(
+          bankAccount.bankId,
+          buildScraperCredentials(bankAccount.bankId, { username, password, card6Digits })
+        );
+      }
       bankAccount.credentials = {
         username,
         password,

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -57,6 +57,8 @@ class BankAccountService {
       if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
         throw new Error('Last 6 card digits must be exactly 6 digits');
       }
+      // Onboarding card flows validate in the queued import so a slow provider
+      // login cannot outlive the HTTP request. Other callers keep this check.
       if (!deferCredentialValidation) {
         await bankScraperService.validateCredentials(
           bankId,
@@ -166,6 +168,8 @@ class BankAccountService {
       if (bankAccount.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
         throw new Error('Last 6 card digits must be exactly 6 digits');
       }
+      // Failed onboarding cards are revalidated by the queued retry, while
+      // regular credential updates still validate before replacing the secret.
       if (!deferCredentialValidation) {
         await bankScraperService.validateCredentials(
           bankAccount.bankId,

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -195,7 +195,8 @@ describe('Onboarding Accounts API', () => {
         expect.objectContaining({
           name: 'Isracard',
           card6Digits: '123456'
-        })
+        }),
+        { deferCredentialValidation: true }
       );
 
       // Verify onboarding structure was updated
@@ -358,7 +359,10 @@ describe('Onboarding Accounts API', () => {
           password: 'new-password',
           card6Digits: undefined
         },
-        { requireQueuedSync: true }
+        {
+          requireQueuedSync: true,
+          deferCredentialValidation: true
+        }
       );
 
       const updatedUser = await User.findById(testUser._id);

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -135,6 +135,8 @@ router.post('/credit-card-account', auth, async (req, res) => {
       username: credentials.username,
       password: credentials.password,
       card6Digits: credentials.card6Digits
+    }, {
+      deferCredentialValidation: true
     });
     
     // Add to onboarding credit card accounts array
@@ -240,7 +242,10 @@ router.put('/credit-card-account/:accountId/credentials', auth, async (req, res)
         accountId,
         userId,
         { username, password, card6Digits },
-        { requireQueuedSync: true }
+        {
+          requireQueuedSync: true,
+          deferCredentialValidation: true
+        }
       );
 
       return res.json({


### PR DESCRIPTION
## What Changed
- Returns onboarding credit-card account creation before slow provider login validation.
- Applies the same behavior to failed-account credential repair.
- Uses the existing background import and onboarding failure-recovery flow to validate credentials and report actionable errors.
- Adds service and API regression coverage for deferred validation.

## Why
Visa CAL login validation can retry three times with a 210-second scraper timeout. Running that validation inside the HTTP request caused Azure Container Apps to time out the POST; Azure's timeout response lacked CORS headers, so browsers misleadingly reported a CORS violation even though the preflight and configured origin were correct.

## Impact Analysis
- Account creation and repair requests return promptly instead of waiting on provider websites.
- Invalid credentials are surfaced asynchronously through the existing onboarding failed-account state.
- Regular account-management flows retain synchronous credential validation.
- No schema, dependency, or configuration changes.

## Quality Gates
- Added tests for deferred account creation and credential repair.
- Full backend and frontend tests, frontend lint, type-check, and build pass.

## Deployment Considerations
Backend-only automatic deployment. No data migration is required.