### PR TITLE
feat(banking): add American Express provider support

### DIFF
--- a/backend/src/auth/models/User.js
+++ b/backend/src/auth/models/User.js
@@ -168,7 +168,7 @@ const userSchema = new mongoose.Schema({
         _id: false,
         bankId: {
           type: String,
-          enum: ['visaCal', 'max', 'isracard']
+          enum: ['visaCal', 'max', 'isracard', 'amex']
         },
         paymentCount: {
           type: Number,

--- a/backend/src/banking/__tests__/BankAccount.test.js
+++ b/backend/src/banking/__tests__/BankAccount.test.js
@@ -138,26 +138,29 @@ describe('BankAccount Model', () => {
       });
     });
 
-    it('should map and decrypt Isracard credentials for the scraper', async () => {
-      const account = await BankAccount.create({
-        ...mockAccount,
-        bankId: 'isracard',
-        credentials: {
-          username: validCredentials.username,
-          password: validCredentials.password,
-          card6Digits: validCredentials.card6Digits
-        }
-      });
+    it.each(['isracard', 'amex'])(
+      'should map and decrypt %s credentials for the scraper',
+      async (bankId) => {
+        const account = await BankAccount.create({
+          ...mockAccount,
+          bankId,
+          credentials: {
+            username: validCredentials.username,
+            password: validCredentials.password,
+            card6Digits: validCredentials.card6Digits
+          }
+        });
 
-      const savedAccount = await BankAccount.findById(account._id);
-      expect(savedAccount.credentials.card6Digits).not.toBe(validCredentials.card6Digits);
-      expect(credentialEncryption.isEncrypted(savedAccount.credentials.card6Digits)).toBe(true);
-      expect((await savedAccount.getScraperOptions()).credentials).toEqual({
-        id: validCredentials.username,
-        card6Digits: validCredentials.card6Digits,
-        password: validCredentials.password
-      });
-    });
+        const savedAccount = await BankAccount.findById(account._id);
+        expect(savedAccount.credentials.card6Digits).not.toBe(validCredentials.card6Digits);
+        expect(credentialEncryption.isEncrypted(savedAccount.credentials.card6Digits)).toBe(true);
+        expect((await savedAccount.getScraperOptions()).credentials).toEqual({
+          id: validCredentials.username,
+          card6Digits: validCredentials.card6Digits,
+          password: validCredentials.password
+        });
+      }
+    );
 
     it('should default first-time scraping to the past year', async () => {
       const before = new Date();

--- a/backend/src/banking/models/BankAccount.js
+++ b/backend/src/banking/models/BankAccount.js
@@ -4,7 +4,7 @@ const { resolveStartDate, DEFAULT_LOOKBACK_MONTHS } = require('../utils/scraperD
 const logger = require('../../shared/utils/logger');
 const { OTP_BANKS } = require('../constants/enums');
 const {
-  ISRACARD_BANK_ID,
+  requiresCard6Digits,
   buildScraperCredentials
 } = require('../utils/scraperCredentials');
 
@@ -17,7 +17,7 @@ const bankAccountSchema = new mongoose.Schema({
   bankId: {
     type: String,
     required: true,
-    enum: ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard', 'mercury', 'ibkr', 'phoenix', 'clal'] // Supported banks
+    enum: ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard', 'amex', 'mercury', 'ibkr', 'phoenix', 'clal'] // Supported banks
   },
   defaultCurrency: {
     type: String,
@@ -254,7 +254,7 @@ bankAccountSchema.methods.getScraperCredentials = async function() {
     password: await credentialEncryption.decryptForUser(this.userId, this.credentials.password)
   };
 
-  if (this.bankId === ISRACARD_BANK_ID) {
+  if (requiresCard6Digits(this.bankId)) {
     credentials.card6Digits = this.credentials.card6Digits
       ? await credentialEncryption.decryptForUser(this.userId, this.credentials.card6Digits)
       : undefined;

--- a/backend/src/banking/routes/__tests__/bankAccounts.test.js
+++ b/backend/src/banking/routes/__tests__/bankAccounts.test.js
@@ -78,13 +78,16 @@ describe('Bank Account Routes', () => {
       expect(response.body).toHaveProperty('error', 'Missing required fields');
     });
 
-    it('should require exactly six card digits for Isracard', async () => {
+    it.each([
+      ['isracard', 'My Isracard'],
+      ['amex', 'My American Express']
+    ])('should require exactly six card digits for %s', async (bankId, name) => {
       const response = await request(app)
         .post('/api/bank-accounts')
         .set('Authorization', `Bearer ${token}`)
         .send({
-          bankId: 'isracard',
-          name: 'My Isracard',
+          bankId,
+          name,
           credentials: {
             username: validCredentials.username,
             password: validCredentials.password,

--- a/backend/src/banking/routes/bankAccounts.js
+++ b/backend/src/banking/routes/bankAccounts.js
@@ -5,8 +5,8 @@ const auth = require('../../shared/middleware/auth');
 const bankAccountService = require('../services/bankAccountService.js');
 const { OTP_BANKS } = require('../constants/enums');
 const {
-  ISRACARD_BANK_ID,
-  isValidCard6Digits
+  isValidCard6Digits,
+  requiresCard6Digits
 } = require('../utils/scraperCredentials');
 
 const router = express.Router();
@@ -42,7 +42,7 @@ router.post('/', auth, async (req, res) => {
       if (!bankId || !name || !credentials?.username || !credentials?.password) {
         return res.status(400).json({ error: 'Missing required fields' });
       }
-      if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(credentials.card6Digits)) {
+      if (requiresCard6Digits(bankId) && !isValidCard6Digits(credentials.card6Digits)) {
         return res.status(400).json({ error: 'Last 6 card digits must be exactly 6 digits' });
       }
     }
@@ -129,7 +129,7 @@ router.put('/:id/credentials', auth, async (req, res) => {
       if (!username || !password) {
         return res.status(400).json({ error: 'Username and password are required' });
       }
-      if (account.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+      if (requiresCard6Digits(account.bankId) && !isValidCard6Digits(card6Digits)) {
         return res.status(400).json({ error: 'Last 6 card digits must be exactly 6 digits' });
       }
     }

--- a/backend/src/banking/services/__tests__/bankAccountService.test.js
+++ b/backend/src/banking/services/__tests__/bankAccountService.test.js
@@ -117,16 +117,16 @@ describe('BankAccountService', () => {
       );
     });
 
-    it('should validate and store Isracard last-six credentials', async () => {
+    it.each(['isracard', 'amex'])('should validate and store %s last-six credentials', async (bankId) => {
       bankScraperService.validateCredentials.mockResolvedValueOnce(true);
 
       const account = await bankAccountService.create(userId, {
         ...mockAccountData,
-        bankId: 'isracard',
+        bankId,
         card6Digits: validCredentials.card6Digits
       });
 
-      expect(bankScraperService.validateCredentials).toHaveBeenCalledWith('isracard', {
+      expect(bankScraperService.validateCredentials).toHaveBeenCalledWith(bankId, {
         id: validCredentials.username,
         card6Digits: validCredentials.card6Digits,
         password: validCredentials.password
@@ -138,10 +138,10 @@ describe('BankAccountService', () => {
       });
     });
 
-    it('should reject Isracard credentials without exactly six card digits', async () => {
+    it.each(['isracard', 'amex'])('should reject %s credentials without exactly six card digits', async (bankId) => {
       await expect(bankAccountService.create(userId, {
         ...mockAccountData,
-        bankId: 'isracard',
+        bankId,
         card6Digits: '12345'
       })).rejects.toThrow('Last 6 card digits must be exactly 6 digits');
 

--- a/backend/src/banking/services/__tests__/bankClassificationService.test.js
+++ b/backend/src/banking/services/__tests__/bankClassificationService.test.js
@@ -20,7 +20,7 @@ describe('BankClassificationService', () => {
   describe('getCreditCardProviders', () => {
     test('should return correct credit card provider IDs', () => {
       const creditProviders = BankClassificationService.getCreditCardProviders();
-      expect(creditProviders).toEqual(['visaCal', 'max', 'isracard']);
+      expect(creditProviders).toEqual(['visaCal', 'max', 'isracard', 'amex']);
     });
     
     test('should return array of strings', () => {
@@ -44,6 +44,7 @@ describe('BankClassificationService', () => {
       expect(BankClassificationService.isCheckingBank('visaCal')).toBe(false);
       expect(BankClassificationService.isCheckingBank('max')).toBe(false);
       expect(BankClassificationService.isCheckingBank('isracard')).toBe(false);
+      expect(BankClassificationService.isCheckingBank('amex')).toBe(false);
     });
     
     test('should return false for unknown bank IDs', () => {
@@ -59,6 +60,7 @@ describe('BankClassificationService', () => {
       expect(BankClassificationService.isCreditCardProvider('visaCal')).toBe(true);
       expect(BankClassificationService.isCreditCardProvider('max')).toBe(true);
       expect(BankClassificationService.isCreditCardProvider('isracard')).toBe(true);
+      expect(BankClassificationService.isCreditCardProvider('amex')).toBe(true);
     });
     
     test('should return false for checking bank IDs', () => {
@@ -79,7 +81,7 @@ describe('BankClassificationService', () => {
   describe('getAllSupportedBanks', () => {
     test('should return all supported banks (checking + credit + api + otp)', () => {
       const allBanks = BankClassificationService.getAllSupportedBanks();
-      const expectedBanks = ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard', 'mercury', 'phoenix', 'clal'];
+      const expectedBanks = ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard', 'amex', 'mercury', 'phoenix', 'clal'];
       expect(allBanks).toEqual(expectedBanks);
     });
     
@@ -92,7 +94,7 @@ describe('BankClassificationService', () => {
   
   describe('isSupportedBank', () => {
     test('should return true for all supported banks', () => {
-      const supportedBanks = ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard'];
+      const supportedBanks = ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard', 'amex'];
       supportedBanks.forEach(bank => {
         expect(BankClassificationService.isSupportedBank(bank)).toBe(true);
       });
@@ -117,6 +119,7 @@ describe('BankClassificationService', () => {
       expect(BankClassificationService.getBankType('visaCal')).toBe('credit');
       expect(BankClassificationService.getBankType('max')).toBe('credit');
       expect(BankClassificationService.getBankType('isracard')).toBe('credit');
+      expect(BankClassificationService.getBankType('amex')).toBe('credit');
     });
     
     test('should return null for unsupported banks', () => {
@@ -135,7 +138,7 @@ describe('BankClassificationService', () => {
     
     test('should return credit card providers for type "credit"', () => {
       const creditProviders = BankClassificationService.getBanksByType('credit');
-      expect(creditProviders).toEqual(['visaCal', 'max', 'isracard']);
+      expect(creditProviders).toEqual(['visaCal', 'max', 'isracard', 'amex']);
     });
     
     test('should return empty array for unknown type', () => {
@@ -174,7 +177,8 @@ describe('BankClassificationService', () => {
       const expected = [
         { id: 'visaCal', name: 'Visa Cal' },
         { id: 'max', name: 'Max' },
-        { id: 'isracard', name: 'Isracard' }
+        { id: 'isracard', name: 'Isracard' },
+        { id: 'amex', name: 'American Express' }
       ];
       expect(providerDetails).toEqual(expected);
     });

--- a/backend/src/banking/services/__tests__/bankScraperService.test.js
+++ b/backend/src/banking/services/__tests__/bankScraperService.test.js
@@ -148,8 +148,8 @@ describe('BankScraperService', () => {
       })).rejects.toThrow('Login failed: Invalid bank credentials');
     });
 
-    it('should preserve Isracard-specific credential fields', async () => {
-      const result = await bankScraperService.validateCredentials('isracard', {
+    it.each(['isracard', 'amex'])('should preserve %s-specific credential fields', async (bankId) => {
+      const result = await bankScraperService.validateCredentials(bankId, {
         id: 'testuser',
         card6Digits: '123456',
         password: 'bankpass123'

--- a/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
+++ b/backend/src/banking/services/__tests__/creditCardDetectionService.test.js
@@ -23,8 +23,10 @@ describe('CreditCardDetectionService', () => {
     const descriptions = [
       'כרטיסי אשראי-י',
       'ישראכרט בע"מ-י',
+      'אמריקן אקספרס בע"מ',
       'דיינרס קלוב-י',
       'Isracard monthly payment',
+      'Amex monthly payment',
       'CAL monthly payment',
       'MAX monthly payment'
     ];
@@ -48,16 +50,17 @@ describe('CreditCardDetectionService', () => {
       new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
     );
 
-    expect(analysis.transactionCount).toBe(6);
+    expect(analysis.transactionCount).toBe(8);
     expect(analysis.recommendation).toBe('connect');
     expect(analysis.suggestedProviders).toEqual([
       { bankId: 'isracard', paymentCount: 2 },
+      { bankId: 'amex', paymentCount: 2 },
       { bankId: 'visaCal', paymentCount: 2 },
       { bankId: 'max', paymentCount: 1 }
     ]);
     expect(paymentMonths).toEqual([
       expect.objectContaining({
-        transactionCount: 6,
+        transactionCount: 8,
         transactions: expect.arrayContaining(
           descriptions.map(description => expect.objectContaining({ description }))
         )

--- a/backend/src/banking/services/bankAccountService.js
+++ b/backend/src/banking/services/bankAccountService.js
@@ -6,9 +6,9 @@ const bankAccountEvents = require('./bankAccountEvents');
 const ForeignCurrencyAccount = require('../../foreign-currency/models/ForeignCurrencyAccount');
 const { OTP_BANKS } = require('../constants/enums');
 const {
-  ISRACARD_BANK_ID,
   buildScraperCredentials,
-  isValidCard6Digits
+  isValidCard6Digits,
+  requiresCard6Digits
 } = require('../utils/scraperCredentials');
 
 const normalizeAccountName = (name) => {
@@ -54,7 +54,7 @@ class BankAccountService {
       credentials = { username, phoneOrEmail };
     } else {
       // Israeli banks use username/password with browser scraping
-      if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+      if (requiresCard6Digits(bankId) && !isValidCard6Digits(card6Digits)) {
         throw new Error('Last 6 card digits must be exactly 6 digits');
       }
       // Onboarding card flows validate in the queued import so a slow provider
@@ -68,7 +68,7 @@ class BankAccountService {
       credentials = {
         username,
         password,
-        ...(bankId === ISRACARD_BANK_ID && { card6Digits })
+        ...(requiresCard6Digits(bankId) && { card6Digits })
       };
     }
 
@@ -167,7 +167,7 @@ class BankAccountService {
       bankAccount.credentials = { flexToken, queryId };
     } else {
       // Israeli banks: validate new credentials before saving
-      if (bankAccount.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+      if (requiresCard6Digits(bankAccount.bankId) && !isValidCard6Digits(card6Digits)) {
         throw new Error('Last 6 card digits must be exactly 6 digits');
       }
       // Failed onboarding cards are revalidated by the queued retry, while
@@ -181,7 +181,7 @@ class BankAccountService {
       bankAccount.credentials = {
         username,
         password,
-        ...(bankAccount.bankId === ISRACARD_BANK_ID && { card6Digits })
+        ...(requiresCard6Digits(bankAccount.bankId) && { card6Digits })
       };
     }
 

--- a/backend/src/banking/services/bankClassificationService.js
+++ b/backend/src/banking/services/bankClassificationService.js
@@ -20,7 +20,7 @@ class BankClassificationService {
    * @returns {string[]} Array of credit card provider IDs
    */
   static getCreditCardProviders() {
-    return ['visaCal', 'max', 'isracard'];
+    return ['visaCal', 'max', 'isracard', 'amex'];
   }
   
   /**
@@ -151,7 +151,8 @@ class BankClassificationService {
     return [
       { id: 'visaCal', name: 'Visa Cal' },
       { id: 'max', name: 'Max' },
-      { id: 'isracard', name: 'Isracard' }
+      { id: 'isracard', name: 'Isracard' },
+      { id: 'amex', name: 'American Express' }
     ];
   }
   

--- a/backend/src/banking/services/bankScraperService.js
+++ b/backend/src/banking/services/bankScraperService.js
@@ -513,7 +513,7 @@ class BankScraperService {
 
   getScraperInfo() {
     return {
-      supportedBanks: ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard'],
+      supportedBanks: ['hapoalim', 'leumi', 'discount', 'otsarHahayal', 'visaCal', 'max', 'isracard', 'amex'],
       defaultSettings: {
         timeout: this.DEFAULT_TIMEOUT,
         maxRetries: this.MAX_RETRIES,

--- a/backend/src/banking/services/creditCardPaymentMatcher.js
+++ b/backend/src/banking/services/creditCardPaymentMatcher.js
@@ -1,8 +1,9 @@
 const CARD_PAYMENT_DESCRIPTION_PATTERN =
-  /^\s*(?:כרטיסי?\s*אשראי|ישראכרט(?:\s+בע"?מ)?|דיינרס(?:\s*קלוב)?|ויזה\s*כאל|מקס\s*(?:איט\s*)?פיננסים|כאל|מקס|credit\s*card(?:\s+payment)?|isracard(?:\s+monthly\s+payment)?|diners(?:\s+club)?(?:\s+monthly\s+payment)?|visa\s*cal(?:\s+monthly\s+payment)?|(?:cal|max)\s+monthly\s+payment)(?:\s*-\s*י)?\s*$/i;
+  /^\s*(?:כרטיסי?\s*אשראי|ישראכרט(?:\s+בע"?מ)?|אמריקן\s*אקספרס(?:\s+בע"?מ)?|אמקס|דיינרס(?:\s*קלוב)?|ויזה\s*כאל|מקס\s*(?:איט\s*)?פיננסים|כאל|מקס|credit\s*card(?:\s+payment)?|isracard(?:\s+monthly\s+payment)?|american\s+express(?:\s+monthly\s+payment)?|amex(?:\s+monthly\s+payment)?|diners(?:\s+club)?(?:\s+monthly\s+payment)?|visa\s*cal(?:\s+monthly\s+payment)?|(?:cal|max)\s+monthly\s+payment)(?:\s*-\s*י)?\s*$/i;
 
 const CREDIT_CARD_PROVIDER_HINTS = [
   { bankId: 'isracard', pattern: /ישראכרט|\bisracard\b/i },
+  { bankId: 'amex', pattern: /אמריקן\s*אקספרס|אמקס|american\s+express|\bamex\b/i },
   { bankId: 'visaCal', pattern: /דיינרס|ויזה\s*כאל|^\s*כאל(?:\s*-\s*י)?\s*$|\bdiners(?:\s+club)?\b|\bvisa\s*cal\b|\bcal\s+monthly\s+payment\b/i },
   { bankId: 'max', pattern: /מקס\s*(?:איט\s*)?פיננסים|^\s*מקס(?:\s*-\s*י)?\s*$|\bmax\s+monthly\s+payment\b/i }
 ];

--- a/backend/src/banking/utils/scraperCredentials.js
+++ b/backend/src/banking/utils/scraperCredentials.js
@@ -1,11 +1,15 @@
 const ISRACARD_BANK_ID = 'isracard';
+const AMEX_BANK_ID = 'amex';
+const CARD6_DIGITS_BANK_IDS = new Set([ISRACARD_BANK_ID, AMEX_BANK_ID]);
 const CARD6_DIGITS_PATTERN = /^\d{6}$/;
+
+const requiresCard6Digits = (bankId) => CARD6_DIGITS_BANK_IDS.has(bankId);
 
 const isValidCard6Digits = (value) =>
   typeof value === 'string' && CARD6_DIGITS_PATTERN.test(value);
 
 const buildScraperCredentials = (bankId, { username, password, card6Digits }) => {
-  if (bankId === ISRACARD_BANK_ID) {
+  if (requiresCard6Digits(bankId)) {
     return {
       id: username,
       card6Digits,
@@ -17,7 +21,9 @@ const buildScraperCredentials = (bankId, { username, password, card6Digits }) =>
 };
 
 module.exports = {
+  AMEX_BANK_ID,
   ISRACARD_BANK_ID,
   buildScraperCredentials,
-  isValidCard6Digits
+  isValidCard6Digits,
+  requiresCard6Digits
 };

--- a/backend/src/onboarding/__tests__/onboardingAccounts.test.js
+++ b/backend/src/onboarding/__tests__/onboardingAccounts.test.js
@@ -213,6 +213,43 @@ describe('Onboarding Accounts API', () => {
       expect(updatedUser.onboarding.creditCardMatching.error).toBeNull();
     });
 
+    it('should add an American Express account with last-six credentials', async () => {
+      const mockAccount = {
+        _id: new mongoose.Types.ObjectId(),
+        userId: testUser._id,
+        bankId: 'amex',
+        accountType: 'creditCard',
+        displayName: 'American Express',
+        isActive: true
+      };
+      bankAccountService.create.mockResolvedValue(mockAccount);
+
+      const response = await request(app)
+        .post('/api/onboarding/credit-card-account')
+        .set('Authorization', 'Bearer ' + authToken)
+        .send({
+          bankId: 'amex',
+          credentials: {
+            username: 'user123',
+            password: 'pass123',
+            card6Digits: '654321'
+          },
+          displayName: 'American Express'
+        });
+
+      expect(response.status).toBe(200);
+      expect(bankAccountService.create).toHaveBeenCalledWith(
+        testUser._id,
+        expect.objectContaining({
+          bankId: 'amex',
+          card6Digits: '654321'
+        }),
+        { deferCredentialValidation: true }
+      );
+      const updatedUser = await User.findById(testUser._id);
+      expect(updatedUser.onboarding.creditCardSetup.creditCardAccounts[0].bankId).toBe('amex');
+    });
+
     it('should allow adding multiple credit card accounts', async () => {
       const mockAccount1 = {
         _id: new mongoose.Types.ObjectId(),
@@ -279,18 +316,21 @@ describe('Onboarding Accounts API', () => {
       expect(bankAccountService.create).not.toHaveBeenCalled();
     });
 
-    it('should reject Isracard without exactly six card digits', async () => {
+    it.each([
+      ['isracard', 'Personal Isracard'],
+      ['amex', 'Personal American Express']
+    ])('should reject %s without exactly six card digits', async (bankId, displayName) => {
       const response = await request(app)
         .post('/api/onboarding/credit-card-account')
         .set('Authorization', `Bearer ${authToken}`)
         .send({
-          bankId: 'isracard',
+          bankId,
           credentials: {
             username: 'user123',
             password: 'pass123',
             card6Digits: '12345'
           },
-          displayName: 'Personal Isracard'
+          displayName
         });
 
       expect(response.status).toBe(400);

--- a/backend/src/onboarding/routes/onboardingAccounts.js
+++ b/backend/src/onboarding/routes/onboardingAccounts.js
@@ -6,8 +6,8 @@ const { User } = require('../../auth');
 const { bankAccountService, Transaction, scrapingEvents } = require('../../banking');
 const onboardingCreditCardDetectionService = require('../services/onboardingCreditCardDetectionService');
 const {
-  ISRACARD_BANK_ID,
-  isValidCard6Digits
+  isValidCard6Digits,
+  requiresCard6Digits
 } = require('../../banking/utils/scraperCredentials');
 
 const serializePopulatedAccount = (account) => {
@@ -121,7 +121,7 @@ router.post('/credit-card-account', auth, async (req, res) => {
         error: 'Username and password are required'
       });
     }
-    if (bankId === ISRACARD_BANK_ID && !isValidCard6Digits(credentials.card6Digits)) {
+    if (requiresCard6Digits(bankId) && !isValidCard6Digits(credentials.card6Digits)) {
       return res.status(400).json({
         success: false,
         error: 'Last 6 card digits must be exactly 6 digits'
@@ -219,7 +219,7 @@ router.put('/credit-card-account/:accountId/credentials', auth, async (req, res)
         error: 'Username and password are required'
       });
     }
-    if (account.bankId === ISRACARD_BANK_ID && !isValidCard6Digits(card6Digits)) {
+    if (requiresCard6Digits(account.bankId) && !isValidCard6Digits(card6Digits)) {
       return res.status(400).json({
         success: false,
         error: 'Last 6 card digits must be exactly 6 digits'

--- a/backend/src/test/mocks/bankScraper.js
+++ b/backend/src/test/mocks/bankScraper.js
@@ -47,18 +47,19 @@ const mockTransactions = [
 module.exports = {
   validCredentials,
   createScraper: (options) => {
+    const requiresCard6Digits = ['isracard', 'amex'].includes(options.companyId);
     const getUsername = credentials =>
-      options.companyId === 'isracard' ? credentials?.id : credentials?.username;
+      requiresCard6Digits ? credentials?.id : credentials?.username;
     const hasRequiredCredentials = credentials =>
       Boolean(
         getUsername(credentials) &&
         credentials?.password &&
-        (options.companyId !== 'isracard' || /^\d{6}$/.test(credentials?.card6Digits))
+        (!requiresCard6Digits || /^\d{6}$/.test(credentials?.card6Digits))
       );
     const hasValidCredentials = credentials =>
       getUsername(credentials) === validCredentials.username &&
       credentials?.password === validCredentials.password &&
-      (options.companyId !== 'isracard' || credentials?.card6Digits === validCredentials.card6Digits);
+      (!requiresCard6Digits || credentials?.card6Digits === validCredentials.card6Digits);
 
     // Add special case for error testing
     if (options.companyId === 'error_bank') {

--- a/docs/ONBOARDING_API_DOCUMENTATION.md
+++ b/docs/ONBOARDING_API_DOCUMENTATION.md
@@ -87,11 +87,14 @@ Adds a credit card account during onboarding and tracks it separately from regul
   "bankId": "isracard",
   "credentials": {
     "username": "user123",
-    "password": "pass123"
+    "password": "pass123",
+    "card6Digits": "123456"
   },
   "displayName": "Isracard Visa" // optional
 }
 ```
+
+American Express accounts use the same credential fields with `"bankId": "amex"`.
 
 **Response:**
 ```json

--- a/docs/ONBOARDING_SYSTEM_README.md
+++ b/docs/ONBOARDING_SYSTEM_README.md
@@ -87,10 +87,17 @@ Add a credit card account during onboarding.
 ```json
 {
   "bankId": "isracard",
-  "credentials": { "username": "...", "password": "..." },
+  "credentials": {
+    "username": "...",
+    "password": "...",
+    "card6Digits": "123456"
+  },
   "displayName": "Isracard" // optional
 }
 ```
+
+American Express uses the same ID number, password, and last-six credential shape with
+`"bankId": "amex"`.
 
 **Response:**
 ```json

--- a/docs/ONBOARDING_TECHNICAL_ARCHITECTURE.md
+++ b/docs/ONBOARDING_TECHNICAL_ARCHITECTURE.md
@@ -150,7 +150,7 @@ must not take down the first page a new user sees.
 #### `frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx`
 **Purpose**: Step 4 - Credit card provider connection
 **Responsibilities**:
-- Show only credit card providers (Visa Cal, Max, Isracard)
+- Show only credit card providers (Visa Cal, Max, Isracard, American Express)
 - Handle credit card account setup
 - Optional step (can be skipped)
 
@@ -321,7 +321,7 @@ Response: {
 **Key Methods**:
 ```javascript
 getCheckingBanks()           // Returns ['hapoalim', 'leumi', 'discount', 'otsarHahayal']
-getCreditCardProviders()     // Returns ['visaCal', 'max', 'isracard']
+getCreditCardProviders()     // Returns ['visaCal', 'max', 'isracard', 'amex']
 isCheckingBank(bankId)       // Boolean check
 isCreditCardProvider(bankId) // Boolean check
 getBankType(bankId)          // Returns 'checking' | 'credit' | null

--- a/frontend/src/components/bank/BankAccountForm.tsx
+++ b/frontend/src/components/bank/BankAccountForm.tsx
@@ -19,7 +19,13 @@ import {
   Typography
 } from '@mui/material';
 import { bankAccountsApi } from '../../services/api/bank';
-import { SUPPORTED_BANKS, isApiBank, isOtpBank } from '../../constants/banks';
+import {
+  SUPPORTED_BANKS,
+  card6DigitsProviderName,
+  isApiBank,
+  isOtpBank,
+  requiresCard6Digits
+} from '../../constants/banks';
 import { BankIcon } from './BankIcon';
 import { track } from '../../utils/analytics';
 import { BANK_ACCOUNT_EVENTS } from '../../constants/analytics';
@@ -75,9 +81,9 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
       bankName: SUPPORTED_BANKS.find(bank => bank.id === formData.bankId)?.name
     });
 
-    if (formData.bankId === 'isracard' && !/^\d{6}$/.test(formData.card6Digits)) {
+    if (requiresCard6Digits(formData.bankId) && !/^\d{6}$/.test(formData.card6Digits)) {
       setLoading(false);
-      setError('Enter the last 6 digits of your Isracard');
+      setError(`Enter the last 6 digits of your ${card6DigitsProviderName(formData.bankId)}`);
       return;
     }
 
@@ -93,7 +99,7 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
         credentials = {
           username: formData.username,
           password: formData.password,
-          ...(formData.bankId === 'isracard' && { card6Digits: formData.card6Digits })
+          ...(requiresCard6Digits(formData.bankId) && { card6Digits: formData.card6Digits })
         };
       }
 
@@ -277,14 +283,14 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
               <TextField
                 fullWidth
                 margin="normal"
-                label={formData.bankId === 'isracard' ? 'ID Number' : 'Username'}
+                label={requiresCard6Digits(formData.bankId) ? 'ID Number' : 'Username'}
                 name="username"
                 value={formData.username}
                 onChange={handleInputChange}
                 required
               />
 
-              {formData.bankId === 'isracard' && (
+              {requiresCard6Digits(formData.bankId) && (
                 <TextField
                   fullWidth
                   margin="normal"
@@ -294,7 +300,7 @@ export const BankAccountForm: React.FC<BankAccountFormProps> = ({
                   onChange={handleInputChange}
                   required
                   inputProps={{ inputMode: 'numeric', pattern: '[0-9]{6}', maxLength: 6 }}
-                  helperText="The last 6 digits of any Isracard registered to this ID"
+                  helperText={`The last 6 digits of any ${card6DigitsProviderName(formData.bankId)} card registered to this ID`}
                 />
               )}
 

--- a/frontend/src/components/bank/UpdateCredentialsDialog.tsx
+++ b/frontend/src/components/bank/UpdateCredentialsDialog.tsx
@@ -14,6 +14,10 @@ import {
 } from '@mui/material';
 import { BankAccount } from '../../services/api/types';
 import { bankAccountsApi } from '../../services/api/bank';
+import {
+  card6DigitsProviderName,
+  requiresCard6Digits
+} from '../../constants/banks';
 
 interface UpdateCredentialsDialogProps {
   open: boolean;
@@ -39,7 +43,8 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
 
   const isMercury = account?.bankId === 'mercury';
   const isIbkr = account?.bankId === 'ibkr';
-  const isIsracard = account?.bankId === 'isracard';
+  const needsCard6Digits = requiresCard6Digits(account?.bankId || '');
+  const cardProviderName = card6DigitsProviderName(account?.bankId || '');
 
   const handleClose = () => {
     if (!loading) {
@@ -74,8 +79,8 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
         setError('Password is required');
         return;
       }
-      if (isIsracard && !/^\d{6}$/.test(card6Digits)) {
-        setError('Enter the last 6 digits of your Isracard');
+      if (needsCard6Digits && !/^\d{6}$/.test(card6Digits)) {
+        setError(`Enter the last 6 digits of your ${cardProviderName}`);
         return;
       }
     }
@@ -104,7 +109,7 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
         await bankAccountsApi.updateCredentials(account._id, {
           username,
           password,
-          ...(isIsracard && { card6Digits })
+          ...(needsCard6Digits && { card6Digits })
         });
       }
       
@@ -199,15 +204,15 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
             ) : (
               <>
                 <TextField
-                  label={isIsracard ? 'ID Number' : 'Username'}
+                  label={needsCard6Digits ? 'ID Number' : 'Username'}
                   type="text"
                   fullWidth
                   value={account.credentials?.username || 'N/A'}
                   disabled
-                  helperText={`${isIsracard ? 'ID number' : 'Username'} cannot be changed. Create a new account if needed.`}
+                  helperText={`${needsCard6Digits ? 'ID number' : 'Username'} cannot be changed. Create a new account if needed.`}
                 />
 
-                {isIsracard && (
+                {needsCard6Digits && (
                   <TextField
                     label="Last 6 card digits"
                     fullWidth
@@ -216,7 +221,7 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
                     onChange={(e) => setCard6Digits(e.target.value.replace(/\D/g, '').slice(0, 6))}
                     disabled={loading || success}
                     inputProps={{ inputMode: 'numeric', pattern: '[0-9]{6}', maxLength: 6 }}
-                    helperText="The last 6 digits of any Isracard registered to this ID"
+                    helperText={`The last 6 digits of any ${cardProviderName} card registered to this ID`}
                   />
                 )}
 
@@ -261,7 +266,7 @@ export const UpdateCredentialsDialog: React.FC<UpdateCredentialsDialogProps> = (
                 ? !apiToken
                 : isIbkr
                   ? !flexToken || !queryId
-                  : !password || (isIsracard && card6Digits.length !== 6))
+                  : !password || (needsCard6Digits && card6Digits.length !== 6))
             }
             startIcon={loading && <CircularProgress size={16} />}
           >

--- a/frontend/src/components/onboarding/chat/__tests__/providerSuggestions.test.ts
+++ b/frontend/src/components/onboarding/chat/__tests__/providerSuggestions.test.ts
@@ -6,10 +6,12 @@ describe('providerSuggestionsFor', () => {
     const detection = {
       analyzed: true,
       analyzedAt: '2026-08-10T20:00:00Z',
-      transactionCount: 4,
+      transactionCount: 6,
       recommendation: 'connect',
       sampleTransactions: [
         { date: '2026-08-01', description: 'Isracard monthly payment', amount: 1000 },
+        { date: '2026-08-01', description: 'American Express monthly payment', amount: 1500 },
+        { date: '2026-08-01', description: 'Amex monthly payment', amount: 1500 },
         { date: '2026-08-01', description: 'Diners Club monthly payment', amount: 2000 },
         { date: '2026-08-01', description: 'CAL monthly payment', amount: 3000 },
         { date: '2026-08-01', description: 'MAX monthly payment', amount: 4000 }
@@ -17,6 +19,7 @@ describe('providerSuggestionsFor', () => {
     } satisfies OnboardingStatus['creditCardDetection'];
 
     expect(providerSuggestionsFor(detection)).toEqual([
+      { bankId: 'amex', name: 'American Express', paymentCount: 2 },
       { bankId: 'visaCal', name: 'Visa Cal', paymentCount: 2 },
       { bankId: 'isracard', name: 'Isracard', paymentCount: 1 },
       { bankId: 'max', name: 'Max', paymentCount: 1 }
@@ -27,11 +30,12 @@ describe('providerSuggestionsFor', () => {
     const detection = {
       analyzed: true,
       analyzedAt: '2026-08-10T20:00:00Z',
-      transactionCount: 6,
+      transactionCount: 8,
       recommendation: 'connect',
       suggestedProviders: [
         { bankId: 'max', paymentCount: 2 },
         { bankId: 'isracard', paymentCount: 2 },
+        { bankId: 'amex', paymentCount: 2 },
         { bankId: 'visaCal', paymentCount: 2 }
       ],
       sampleTransactions: []
@@ -39,6 +43,7 @@ describe('providerSuggestionsFor', () => {
 
     expect(providerSuggestionsFor(detection).map(({ bankId }) => bankId)).toEqual([
       'isracard',
+      'amex',
       'visaCal',
       'max'
     ]);

--- a/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
+++ b/frontend/src/components/onboarding/chat/cards/CreditCardFormCard.tsx
@@ -9,7 +9,11 @@ import {
 } from '@mui/material';
 import { Lock as LockIcon } from '@mui/icons-material';
 import { AxiosError } from 'axios';
-import { CREDIT_CARD_PROVIDERS } from '../../../../constants/banks';
+import {
+  CREDIT_CARD_PROVIDERS,
+  card6DigitsProviderName,
+  requiresCard6Digits
+} from '../../../../constants/banks';
 import { BankPicker } from '../../../bank/BankPicker';
 import { CardShell } from '../CardShell';
 import { CardProps } from '../types';
@@ -74,8 +78,8 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
       setError('Please fill in all required fields');
       return;
     }
-    if (form.bankId === 'isracard' && !/^\d{6}$/.test(form.card6Digits)) {
-      setError('Enter the last 6 digits of your Isracard');
+    if (requiresCard6Digits(form.bankId) && !/^\d{6}$/.test(form.card6Digits)) {
+      setError(`Enter the last 6 digits of your ${card6DigitsProviderName(form.bankId)}`);
       return;
     }
 
@@ -86,7 +90,7 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
         {
           username: form.username,
           password: form.password,
-          ...(form.bankId === 'isracard' && { card6Digits: form.card6Digits })
+          ...(requiresCard6Digits(form.bankId) && { card6Digits: form.card6Digits })
         },
         form.accountName.trim()
       );
@@ -145,7 +149,7 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
           fullWidth
           margin="dense"
           size="small"
-          label={form.bankId === 'isracard' ? 'ID Number' : 'Username'}
+          label={requiresCard6Digits(form.bankId) ? 'ID Number' : 'Username'}
           name="username"
           value={form.username}
           onChange={handleText}
@@ -153,7 +157,7 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
           data-testid="cc-username-input"
         />
 
-        {form.bankId === 'isracard' && (
+        {requiresCard6Digits(form.bankId) && (
           <TextField
             fullWidth
             margin="dense"
@@ -164,7 +168,7 @@ export const CreditCardFormCard: React.FC<CardProps> = ({ status, handlers }) =>
             onChange={handleText}
             required
             inputProps={{ inputMode: 'numeric', pattern: '[0-9]{6}', maxLength: 6 }}
-            helperText="The last 6 digits of any Isracard registered to this ID"
+            helperText={`The last 6 digits of any ${card6DigitsProviderName(form.bankId)} card registered to this ID`}
             data-testid="cc-card6-input"
           />
         )}

--- a/frontend/src/components/onboarding/chat/cards/FailedCardAccountActions.tsx
+++ b/frontend/src/components/onboarding/chat/cards/FailedCardAccountActions.tsx
@@ -10,6 +10,10 @@ import {
 } from '@mui/material';
 import axios from 'axios';
 import { OnboardingStatus } from '../../../../services/api/onboarding';
+import {
+  card6DigitsProviderName,
+  requiresCard6Digits
+} from '../../../../constants/banks';
 import { ChatHandlers } from '../types';
 
 interface FailedCardAccountActionsProps {
@@ -60,7 +64,8 @@ export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> =
   });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
-  const isIsracard = account.bankId === 'isracard';
+  const needsCard6Digits = requiresCard6Digits(account.bankId);
+  const cardProviderName = card6DigitsProviderName(account.bankId);
 
   useEffect(() => {
     setMode('summary');
@@ -89,8 +94,8 @@ export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> =
       setError('Please enter the username and new password');
       return;
     }
-    if (isIsracard && !/^\d{6}$/.test(form.card6Digits)) {
-      setError('Enter the last 6 digits of your Isracard');
+    if (needsCard6Digits && !/^\d{6}$/.test(form.card6Digits)) {
+      setError(`Enter the last 6 digits of your ${cardProviderName}`);
       return;
     }
 
@@ -99,7 +104,7 @@ export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> =
       await handlers.repairCreditCardAccount(account.accountId, {
         username: form.username,
         password: form.password,
-        ...(isIsracard && { card6Digits: form.card6Digits })
+        ...(needsCard6Digits && { card6Digits: form.card6Digits })
       });
     } catch (err) {
       setError(apiErrorMessage(err));
@@ -212,7 +217,7 @@ export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> =
             fullWidth
             margin="dense"
             size="small"
-            label={isIsracard ? 'ID Number' : 'Username'}
+            label={needsCard6Digits ? 'ID Number' : 'Username'}
             name="username"
             value={form.username}
             onChange={handleText}
@@ -220,7 +225,7 @@ export const FailedCardAccountActions: React.FC<FailedCardAccountActionsProps> =
             required
             inputProps={{ 'data-testid': 'repair-card-username' }}
           />
-          {isIsracard && (
+          {needsCard6Digits && (
             <TextField
               fullWidth
               margin="dense"

--- a/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
+++ b/frontend/src/components/onboarding/chat/cards/__tests__/CreditCardFormCard.test.tsx
@@ -145,6 +145,24 @@ describe('CreditCardFormCard submission', () => {
     );
   });
 
+  it('submits American Express credentials with the required last six digits', async () => {
+    const group = showCard();
+
+    fireEvent.click(within(group).getByRole('radio', { name: 'American Express' }));
+    fireEvent.change(screen.getByLabelText(/id number/i), { target: { value: 'someone' } });
+    fireEvent.change(screen.getByLabelText(/last 6 card digits/i), { target: { value: '654321' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByTestId('connect-cards-btn'));
+
+    await waitFor(() =>
+      expect(handlers.connectCreditCardAccount).toHaveBeenCalledWith(
+        'amex',
+        { username: 'someone', password: 'secret', card6Digits: '654321' },
+        'American Express account 1'
+      )
+    );
+  });
+
   it('lets the user give the account a recognizable name', async () => {
     const group = showCard();
 

--- a/frontend/src/components/onboarding/chat/providerSuggestions.ts
+++ b/frontend/src/components/onboarding/chat/providerSuggestions.ts
@@ -7,6 +7,7 @@ import { OnboardingStatus } from '../../../services/api/onboarding';
 // before that field was introduced.
 const PROVIDER_HINTS = [
   { bankId: 'isracard', pattern: /ישראכרט|\bisracard\b/i },
+  { bankId: 'amex', pattern: /אמריקן\s*אקספרס|אמקס|american\s+express|\bamex\b/i },
   { bankId: 'visaCal', pattern: /דיינרס|ויזה\s*כאל|^\s*כאל(?:\s*-\s*י)?\s*$|\bdiners(?:\s+club)?\b|\bvisa\s*cal\b|\bcal\s+monthly\s+payment\b/i },
   { bankId: 'max', pattern: /מקס\s*(?:איט\s*)?פיננסים|^\s*מקס(?:\s*-\s*י)?\s*$|\bmax\s+monthly\s+payment\b/i }
 ];

--- a/frontend/src/constants/banks.ts
+++ b/frontend/src/constants/banks.ts
@@ -32,7 +32,8 @@ export const CHECKING_ACCOUNT_BANKS: SupportedBank[] = [
 export const CREDIT_CARD_PROVIDERS: SupportedBank[] = [
   { id: 'visaCal', name: 'Visa Cal', monogram: 'CAL', color: '#0057B8', logo: '/banks/visaCal.png' },
   { id: 'max', name: 'Max', monogram: 'MAX', color: '#5B2C86', logo: '/banks/max.png' },
-  { id: 'isracard', name: 'Isracard', monogram: 'ISR', color: '#E4761B', logo: '/banks/isracard.png' }
+  { id: 'isracard', name: 'Isracard', monogram: 'ISR', color: '#E4761B', logo: '/banks/isracard.png' },
+  { id: 'amex', name: 'American Express', monogram: 'AMX', color: '#006FCF' }
 ];
 
 // API-based banks (token-based REST API, no browser scraping)
@@ -87,6 +88,14 @@ export const isApiBank = (bankId: string): boolean => {
 export const isOtpBank = (bankId: string): boolean => {
   return OTP_BANKS.some(bank => bank.id === bankId);
 };
+
+const CARD6_DIGITS_PROVIDER_IDS = new Set(['isracard', 'amex']);
+
+export const requiresCard6Digits = (bankId: string): boolean =>
+  CARD6_DIGITS_PROVIDER_IDS.has(bankId);
+
+export const card6DigitsProviderName = (bankId: string): string =>
+  bankId === 'amex' ? 'American Express' : 'Isracard';
 
 export const getBankStrategies = (bankId?: string): string[] => {
   switch (bankId) {


### PR DESCRIPTION
## What Changed
- Added American Express (`amex`) as a supported credit-card provider across account schemas, classification, scraper metadata, onboarding, and regular account management.
- Generalized ID number + password + last-six credential handling so both Isracard and American Express use the scraper-required `{ id, card6Digits, password }` shape while retaining encrypted storage.
- Added American Express settlement detection, provider suggestions, UI selection, credential creation/update/recovery flows, and a monogram fallback.
- Updated onboarding documentation and regression coverage for credential mapping, validation, provider inference, and form submission.

## Why
The upstream `israeli-bank-scrapers` package exposes American Express as a separate provider from Isracard. Users therefore need a distinct American Express connection to import those cards and transactions.

## Impact Analysis
- No new dependency or database migration is required; the installed scraper dependency already exposes `CompanyTypes.amex`.
- Existing Isracard behavior is preserved through the shared last-six provider path.
- American Express credentials use the existing per-user encryption flow.

## Quality Gates
- Backend: full Jest suite passed.
- Frontend: full Jest suite, ESLint, TypeScript check, and production build passed.
- Documentation updated for the new provider and credential shape.

## Deployment Considerations
Deploy through the normal backend and frontend pipelines. After deployment, American Express must be connected as a separate provider account.