### PR TITLE
fix(deploy): ship Amex Cloudflare workaround

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,8 +14,8 @@ FROM node:22-bookworm AS scraper-build
 ARG SCRAPER_REPO=https://github.com/geriamir/israeli-bank-scrapers.git
 # Pinned to a commit so an image rebuild is reproducible; a branch name would let
 # the dependency change underneath an otherwise identical build. Bump deliberately
-# after verifying the new scraper commit: git rev-parse origin/feature/add-foreign-currency
-ARG SCRAPER_REF=5351a5020745d411d701f1dba66e0092fcccfc80
+# after verifying the new scraper commit: git rev-parse origin/fix/amex-cloudflare-waf
+ARG SCRAPER_REF=1965a8bfffb8e481ae83ced31a2969fba27b0902
 
 WORKDIR /scraper
 


### PR DESCRIPTION
## What Changed
- Updated the backend Docker image to pin `geriamir/israeli-bank-scrapers` commit `1965a8b`, which adds the Amex/Isracard Cloudflare fingerprint workaround.
- The pinned scraper commit also detects Cloudflare block pages explicitly and removes request values from propagated parse errors.

## Why
American Express login from Azure Container Apps was returning a Cloudflare HTML block page from `ValidateIdData`, so the scraper attempted to parse HTML as JSON and account creation failed.

## Impact Analysis
- Backend deployment only; no database, API, or frontend changes.
- The shared workaround also applies to Isracard login.
- Sensitive request values are no longer embedded in scraper parse errors.

## Quality Gates
- Scraper PR: https://github.com/geriamir/israeli-bank-scrapers/pull/2
- Full scraper Jest suite, lint, formatting, type-check, and build passed.
- The workaround was exercised from the running Azure container against the Amex validation endpoint with dummy credentials; navigation returned 200 and the validation response was no longer HTML.
- Confirmed the Docker build's exact shallow-fetch command can retrieve the pinned commit from GitHub. Docker itself is not installed on this workstation.

## Deployment Considerations
Merging this PR triggers the normal backend image build and Container Apps rollout. Retry adding the American Express account after the new revision is healthy.