### PR TITLE
fix(deploy): remove blocked Amex fingerprint mocks

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,7 @@ ARG SCRAPER_REPO=https://github.com/geriamir/israeli-bank-scrapers.git
 # Pinned to a commit so an image rebuild is reproducible; a branch name would let
 # the dependency change underneath an otherwise identical build. Bump deliberately
 # after verifying the new scraper commit: git rev-parse origin/fix/amex-cloudflare-waf
-ARG SCRAPER_REF=1965a8bfffb8e481ae83ced31a2969fba27b0902
+ARG SCRAPER_REF=c48b42d989e9b95976bfb9f47f7355a7033f7ef9
 
 WORKDIR /scraper
 


### PR DESCRIPTION
## What Changed
- Bumped the pinned scraper commit from `1965a8b` to `c48b42d`.
- The corrected scraper keeps the Chrome client hints and `navigator.webdriver` override but removes synthetic `navigator.plugins` and `navigator.languages` values.

## Why
The first Cloudflare workaround was deployed, but Amex still returned 403. Isolation testing showed the fake plugins/languages fingerprint copied from the upstream suggestion is itself detected by the current Amex Cloudflare rules. The same validation request succeeds when those two mocks are removed.

## Impact Analysis
- Backend deployment only; no API, database, or frontend changes.
- Isracard and Amex retain the successful User-Agent/client-hint hardening.
- Credential-value redaction remains enabled.

## Quality Gates
- Updated scraper PR: https://github.com/geriamir/israeli-bank-scrapers/pull/2
- Full scraper tests and package build passed.
- The real scraper flow with dummy credentials no longer receives a Cloudflare/403 response after removing the detectable mocks.
- Confirmed the deployment's shallow fetch can retrieve the exact pinned commit.

## Deployment Considerations
Merging triggers the normal backend rollout. Retry adding American Express after the new Container Apps revision is healthy.